### PR TITLE
[Docs] Add design consensus gate after technical bootstrap

### DIFF
--- a/docs/engineering-rules.md
+++ b/docs/engineering-rules.md
@@ -114,6 +114,8 @@ Este documento convierte el marco de `AGENTS.md` en comportamiento técnico conc
   - `Depends on` (issues bloqueantes)
   - `Blocks` o `Unblocks` (issues dependientes)
 - Un issue no puede pasar a cerrado si sus `Depends on` no están cerradas.
+- Para tareas de UI, no empezar implementación visual sin cerrar antes el issue de consenso de diseño vigente en el roadmap (`Issue #13`) o su sucesor explícito.
+- Las PR de UI deben incluir una referencia trazable a ese issue de consenso (`Depends on` o `Refs`), además del issue funcional de la tarea.
 
 ## Higiene de cambios
 - No renombrar archivos, mover directorios o reorganizar estructura sin necesidad directa.

--- a/docs/implementation-roadmap.md
+++ b/docs/implementation-roadmap.md
@@ -4,7 +4,7 @@
 Convert the documentation-first repository into a production-ready native iPhone app through small, reversible milestones.
 
 ## DoD transversal
-- Para hitos con código (`Hito 2` en adelante), el cierre se evalúa con el checklist ejecutable definido en `docs/engineering-rules.md` (compilación, lint, tests, logs y validación visual cuando aplique).
+- Para hitos con código (`Hito 1` en adelante), el cierre se evalúa con el checklist ejecutable definido en `docs/engineering-rules.md` (compilación, lint, tests, logs y validación visual cuando aplique).
 - `Hito 0` es documental y se valida con su DoD específico.
 - `Hito 1.5` es documental y se valida con su DoD específico.
 

--- a/docs/implementation-roadmap.md
+++ b/docs/implementation-roadmap.md
@@ -4,12 +4,14 @@
 Convert the documentation-first repository into a production-ready native iPhone app through small, reversible milestones.
 
 ## DoD transversal
-- Para hitos con código (`Hito 1` en adelante), el cierre se evalúa con el checklist ejecutable definido en `docs/engineering-rules.md` (compilación, lint, tests, logs y validación visual cuando aplique).
+- Para hitos con código (`Hito 2` en adelante), el cierre se evalúa con el checklist ejecutable definido en `docs/engineering-rules.md` (compilación, lint, tests, logs y validación visual cuando aplique).
 - `Hito 0` es documental y se valida con su DoD específico.
+- `Hito 1.5` es documental y se valida con su DoD específico.
 
 ## Dependencias entre hitos
 - `Hito 0 -> Hito 1`
-- `Hito 1 -> Hito 2`
+- `Hito 1 -> Hito 1.5`
+- `Hito 1.5 -> Hito 2`
 - `Hito 2 -> Hito 3`
 - `Hito 3 -> Hito 4`
 - `Hito 3 -> Hito 6`
@@ -51,6 +53,21 @@ Convert the documentation-first repository into a production-ready native iPhone
 - añadir `TCA` y `sqlite-data`
 - crear shell base con tabs y tests mínimos
 - configurar CI inicial de `build` y `test`
+
+### Hito 1.5 — Consenso de diseño visual
+- issue objetivo: `#13`
+- cerrar contrato visual de implementación en `docs/ui-direction.md`
+- fijar tokens, semántica y patrones UI mínimos antes de empezar features visuales
+- dejar trazabilidad explícita de dependencias `Depends on` y `Blocks` para issues de UI
+
+#### Definition of Done (DoD)
+- `Issue #13` cerrada con consenso explícito documentado
+- `docs/ui-direction.md` define baseline accionable para ejecución iOS
+- hitos/issues de UI referencian la dependencia de consenso visual
+
+#### Validación mínima obligatoria
+- revisar consistencia con `AGENTS.md`, `docs/product-spec.md` y `docs/ios-architecture.md`
+- verificar que la secuencia de dependencias del roadmap impide saltar directamente de bootstrap a implementación UI
 
 ### Hito 2 — Núcleo de dominio y dependencias
 - modelar tipos base de negocio

--- a/docs/ui-direction.md
+++ b/docs/ui-direction.md
@@ -1,5 +1,33 @@
 # UI Direction
 
+## Gate de consenso (Issue #13)
+- Este documento actúa como contrato de diseño para la `Issue #13` (`[Design] Define and approve app visual design baseline`).
+- Las tareas con implementación visual deben tratar este baseline como prerequisito de ejecución.
+- Dependencias actuales de trazabilidad:
+  - `Depends on`: `#4` (Technical Bootstrap)
+  - `Blocks`: `#6`, `#7`, `#8`, `#9`, `#10`
+- Ninguna issue de UI debe cerrarse sin referenciar este contrato y sus decisiones cerradas.
+
+## Entregables mínimos de consenso
+- Tokenización base cerrada:
+  - roles de color (`cheap`, `mid`, `expensive`, fondos y superficies)
+  - jerarquía tipográfica
+  - reglas de spacing, radius y elevación visual
+- Patrones de pantalla cerrados para:
+  - resumen diario
+  - lista horaria
+  - interacción de gráfica
+  - ajustes y notificaciones locales
+- Criterios mínimos de accesibilidad listos para validación en implementación:
+  - contraste suficiente
+  - semántica no dependiente solo de color
+  - touch targets cómodos
+  - formatos `es-ES`
+- Registro de decisiones:
+  - decisiones cerradas
+  - decisiones abiertas
+  - fecha y responsable de cada cierre
+
 ## Intención visual
 La app debe transmitir control, claridad y rapidez de lectura. La referencia es un producto iPhone oscuro, contemporáneo y claramente nativo, con información energética legible de un vistazo.
 


### PR DESCRIPTION
## Summary
- add a dedicated design consensus milestone (Hito 1.5) between Technical Bootstrap and implementation milestones
- document Issue #13 as the explicit visual baseline gate in UI direction
- enforce a UI dependency rule in engineering rules so UI work cannot start without a closed design-consensus issue

## Traceability
- Refs #13
- Depends on #4
- Blocks #6, #7, #8, #9, #10

## Validation
- documentation-only change
- terminology and dependency chain reviewed for consistency across AGENTS.md and docs/*
