### PR TITLE
Implement issue #5 domain pipeline and acceptance coverage

### DIFF
--- a/PrecioLuzApp.xcodeproj/project.pbxproj
+++ b/PrecioLuzApp.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0F51D007FF797C2528199A19 /* DailyPricingSnapshotPipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1E5EE190D8DB8B3B216D13 /* DailyPricingSnapshotPipelineTests.swift */; };
 		324A8B65E4B3AE6929DAC3AF /* PricingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CD7FDA5CB1305816A882113 /* PricingClient.swift */; };
 		32965E2DB2F87CDF4A850149 /* AppFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20AF13249077EB2D15ECE90 /* AppFeatureTests.swift */; };
+		48ADECD7D1DB8A2363D06077 /* Issue5AcceptanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE589D64FFD105C083825C13 /* Issue5AcceptanceTests.swift */; };
 		4C0BAE6A4CB9433F43182C37 /* DomainModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75905F6274FE9F8BFD18AA70 /* DomainModels.swift */; };
 		5E5746E4E23EC6B3BD28CE34 /* DailyPricingSnapshotPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2BBD1FCB478C16D91769556 /* DailyPricingSnapshotPipeline.swift */; };
 		628CD71F5793AFE56AFA1109 /* TCASmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C43BF8A9E6F9D897404A6074 /* TCASmokeTests.swift */; };
@@ -39,13 +40,13 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		07E8C05629B788AE315B0D11 /* PrecioLuzAppTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = PrecioLuzAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		07E8C05629B788AE315B0D11 /* PrecioLuzAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PrecioLuzAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1A1E5EE190D8DB8B3B216D13 /* DailyPricingSnapshotPipelineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyPricingSnapshotPipelineTests.swift; sourceTree = "<group>"; };
 		1FC5C7E5F151FC11C56A3D19 /* ChartFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartFeature.swift; sourceTree = "<group>"; };
 		2747995B05A5F06C74D942BF /* DomainModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainModelsTests.swift; sourceTree = "<group>"; };
 		288DF63F4693A0161011B4A4 /* AppFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFeature.swift; sourceTree = "<group>"; };
 		5CD7FDA5CB1305816A882113 /* PricingClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PricingClient.swift; sourceTree = "<group>"; };
-		741F0D1CD612C8F05168C6B2 /* PrecioLuzApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = PrecioLuzApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		741F0D1CD612C8F05168C6B2 /* PrecioLuzApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PrecioLuzApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		75905F6274FE9F8BFD18AA70 /* DomainModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainModels.swift; sourceTree = "<group>"; };
 		8560ED2DC8C618B58A3BF47D /* PersistenceClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceClient.swift; sourceTree = "<group>"; };
 		85CBEA5E1ECD0491F94E0DBA /* SettingsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsFeature.swift; sourceTree = "<group>"; };
@@ -55,6 +56,7 @@
 		A20AF13249077EB2D15ECE90 /* AppFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFeatureTests.swift; sourceTree = "<group>"; };
 		A2868808D917525D9B949780 /* ClientDependenciesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientDependenciesTests.swift; sourceTree = "<group>"; };
 		A349262256B13A6827F96952 /* PricesFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PricesFeature.swift; sourceTree = "<group>"; };
+		BE589D64FFD105C083825C13 /* Issue5AcceptanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Issue5AcceptanceTests.swift; sourceTree = "<group>"; };
 		C43BF8A9E6F9D897404A6074 /* TCASmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCASmokeTests.swift; sourceTree = "<group>"; };
 		F2BBD1FCB478C16D91769556 /* DailyPricingSnapshotPipeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyPricingSnapshotPipeline.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -170,6 +172,7 @@
 				A2868808D917525D9B949780 /* ClientDependenciesTests.swift */,
 				1A1E5EE190D8DB8B3B216D13 /* DailyPricingSnapshotPipelineTests.swift */,
 				2747995B05A5F06C74D942BF /* DomainModelsTests.swift */,
+				BE589D64FFD105C083825C13 /* Issue5AcceptanceTests.swift */,
 				C43BF8A9E6F9D897404A6074 /* TCASmokeTests.swift */,
 			);
 			path = Tests;
@@ -242,9 +245,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 1430;
-				TargetAttributes = {
-				};
+				LastUpgradeCheck = 2640;
 			};
 			buildConfigurationList = 8EB1EA652AF1EAED259FD075 /* Build configuration list for PBXProject "PrecioLuzApp" */;
 			developmentRegion = en;
@@ -297,6 +298,7 @@
 				D5C9D8D8D1D9B4387E66B778 /* ClientDependenciesTests.swift in Sources */,
 				0F51D007FF797C2528199A19 /* DailyPricingSnapshotPipelineTests.swift in Sources */,
 				9DF2CCB727E5BE82950696DA /* DomainModelsTests.swift in Sources */,
+				48ADECD7D1DB8A2363D06077 /* Issue5AcceptanceTests.swift in Sources */,
 				628CD71F5793AFE56AFA1109 /* TCASmokeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -383,6 +385,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -396,6 +399,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_STRICT_CONCURRENCY = complete;
@@ -457,6 +461,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -477,6 +482,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_STRICT_CONCURRENCY = complete;

--- a/PrecioLuzApp.xcodeproj/project.pbxproj
+++ b/PrecioLuzApp.xcodeproj/project.pbxproj
@@ -8,9 +8,11 @@
 
 /* Begin PBXBuildFile section */
 		0707733D9FC9E87DBB20DE2B /* PersistenceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8560ED2DC8C618B58A3BF47D /* PersistenceClient.swift */; };
+		0F51D007FF797C2528199A19 /* DailyPricingSnapshotPipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1E5EE190D8DB8B3B216D13 /* DailyPricingSnapshotPipelineTests.swift */; };
 		324A8B65E4B3AE6929DAC3AF /* PricingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CD7FDA5CB1305816A882113 /* PricingClient.swift */; };
 		32965E2DB2F87CDF4A850149 /* AppFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20AF13249077EB2D15ECE90 /* AppFeatureTests.swift */; };
 		4C0BAE6A4CB9433F43182C37 /* DomainModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75905F6274FE9F8BFD18AA70 /* DomainModels.swift */; };
+		5E5746E4E23EC6B3BD28CE34 /* DailyPricingSnapshotPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2BBD1FCB478C16D91769556 /* DailyPricingSnapshotPipeline.swift */; };
 		628CD71F5793AFE56AFA1109 /* TCASmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C43BF8A9E6F9D897404A6074 /* TCASmokeTests.swift */; };
 		693300BDC4A7882348CC27BB /* SQLiteData in Frameworks */ = {isa = PBXBuildFile; productRef = 4188B8C7C367C21C44A8C549 /* SQLiteData */; };
 		800D4B667AA0009EDF34F4A4 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = C64AB47F534C3EF47DA37C60 /* ComposableArchitecture */; };
@@ -38,6 +40,7 @@
 
 /* Begin PBXFileReference section */
 		07E8C05629B788AE315B0D11 /* PrecioLuzAppTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = PrecioLuzAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		1A1E5EE190D8DB8B3B216D13 /* DailyPricingSnapshotPipelineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyPricingSnapshotPipelineTests.swift; sourceTree = "<group>"; };
 		1FC5C7E5F151FC11C56A3D19 /* ChartFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartFeature.swift; sourceTree = "<group>"; };
 		2747995B05A5F06C74D942BF /* DomainModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainModelsTests.swift; sourceTree = "<group>"; };
 		288DF63F4693A0161011B4A4 /* AppFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFeature.swift; sourceTree = "<group>"; };
@@ -53,6 +56,7 @@
 		A2868808D917525D9B949780 /* ClientDependenciesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientDependenciesTests.swift; sourceTree = "<group>"; };
 		A349262256B13A6827F96952 /* PricesFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PricesFeature.swift; sourceTree = "<group>"; };
 		C43BF8A9E6F9D897404A6074 /* TCASmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCASmokeTests.swift; sourceTree = "<group>"; };
+		F2BBD1FCB478C16D91769556 /* DailyPricingSnapshotPipeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyPricingSnapshotPipeline.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -164,6 +168,7 @@
 			children = (
 				A20AF13249077EB2D15ECE90 /* AppFeatureTests.swift */,
 				A2868808D917525D9B949780 /* ClientDependenciesTests.swift */,
+				1A1E5EE190D8DB8B3B216D13 /* DailyPricingSnapshotPipelineTests.swift */,
 				2747995B05A5F06C74D942BF /* DomainModelsTests.swift */,
 				C43BF8A9E6F9D897404A6074 /* TCASmokeTests.swift */,
 			);
@@ -181,6 +186,7 @@
 		FC9E4DC28FEBF626F3076DB2 /* Domain */ = {
 			isa = PBXGroup;
 			children = (
+				F2BBD1FCB478C16D91769556 /* DailyPricingSnapshotPipeline.swift */,
 				75905F6274FE9F8BFD18AA70 /* DomainModels.swift */,
 			);
 			path = Domain;
@@ -271,6 +277,7 @@
 			files = (
 				E4A687F3008BBA0F8B3C409C /* AppFeature.swift in Sources */,
 				C38E3205CBA69E8FEEC1230F /* ChartFeature.swift in Sources */,
+				5E5746E4E23EC6B3BD28CE34 /* DailyPricingSnapshotPipeline.swift in Sources */,
 				BE6F8B2F22DC95595232845A /* DateClient.swift in Sources */,
 				4C0BAE6A4CB9433F43182C37 /* DomainModels.swift in Sources */,
 				FFD909BEA040F73D5FEDDC2D /* NotificationClient.swift in Sources */,
@@ -288,6 +295,7 @@
 			files = (
 				32965E2DB2F87CDF4A850149 /* AppFeatureTests.swift in Sources */,
 				D5C9D8D8D1D9B4387E66B778 /* ClientDependenciesTests.swift in Sources */,
+				0F51D007FF797C2528199A19 /* DailyPricingSnapshotPipelineTests.swift in Sources */,
 				9DF2CCB727E5BE82950696DA /* DomainModelsTests.swift in Sources */,
 				628CD71F5793AFE56AFA1109 /* TCASmokeTests.swift in Sources */,
 			);
@@ -390,6 +398,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 6.0;
 			};
 			name = Release;
@@ -470,6 +479,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;

--- a/PrecioLuzApp.xcodeproj/project.pbxproj
+++ b/PrecioLuzApp.xcodeproj/project.pbxproj
@@ -7,15 +7,21 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0707733D9FC9E87DBB20DE2B /* PersistenceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8560ED2DC8C618B58A3BF47D /* PersistenceClient.swift */; };
+		324A8B65E4B3AE6929DAC3AF /* PricingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CD7FDA5CB1305816A882113 /* PricingClient.swift */; };
 		32965E2DB2F87CDF4A850149 /* AppFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20AF13249077EB2D15ECE90 /* AppFeatureTests.swift */; };
 		628CD71F5793AFE56AFA1109 /* TCASmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C43BF8A9E6F9D897404A6074 /* TCASmokeTests.swift */; };
-		800D4B667AA0009EDF34F4A4 /* SQLiteData in Frameworks */ = {isa = PBXBuildFile; productRef = 4188B8C7C367C21C44A8C549 /* SQLiteData */; };
+		693300BDC4A7882348CC27BB /* SQLiteData in Frameworks */ = {isa = PBXBuildFile; productRef = 4188B8C7C367C21C44A8C549 /* SQLiteData */; };
+		800D4B667AA0009EDF34F4A4 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = C64AB47F534C3EF47DA37C60 /* ComposableArchitecture */; };
 		85ABD8BD485CCA4876B101A7 /* SettingsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85CBEA5E1ECD0491F94E0DBA /* SettingsFeature.swift */; };
 		9B13DE84E95AAB6D55816805 /* PricesFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = A349262256B13A6827F96952 /* PricesFeature.swift */; };
+		BE6F8B2F22DC95595232845A /* DateClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F488EF3222A15A96E4F3CF /* DateClient.swift */; };
 		C38E3205CBA69E8FEEC1230F /* ChartFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC5C7E5F151FC11C56A3D19 /* ChartFeature.swift */; };
 		CE2C0DE70A00C8DB9F34406B /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = B05968D2E8CFF8E01B748541 /* ComposableArchitecture */; };
 		D4F2BDEAF0E519BD8DCB871B /* PrecioLuzAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EA85C7AECFB312B3FB9D051 /* PrecioLuzAppApp.swift */; };
+		D5C9D8D8D1D9B4387E66B778 /* ClientDependenciesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2868808D917525D9B949780 /* ClientDependenciesTests.swift */; };
 		E4A687F3008BBA0F8B3C409C /* AppFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 288DF63F4693A0161011B4A4 /* AppFeature.swift */; };
+		FFD909BEA040F73D5FEDDC2D /* NotificationClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DEBD7F1E386956FE512E3D6 /* NotificationClient.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -32,10 +38,15 @@
 		07E8C05629B788AE315B0D11 /* PrecioLuzAppTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = PrecioLuzAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1FC5C7E5F151FC11C56A3D19 /* ChartFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartFeature.swift; sourceTree = "<group>"; };
 		288DF63F4693A0161011B4A4 /* AppFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFeature.swift; sourceTree = "<group>"; };
+		5CD7FDA5CB1305816A882113 /* PricingClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PricingClient.swift; sourceTree = "<group>"; };
 		741F0D1CD612C8F05168C6B2 /* PrecioLuzApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = PrecioLuzApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		8560ED2DC8C618B58A3BF47D /* PersistenceClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceClient.swift; sourceTree = "<group>"; };
 		85CBEA5E1ECD0491F94E0DBA /* SettingsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsFeature.swift; sourceTree = "<group>"; };
+		98F488EF3222A15A96E4F3CF /* DateClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateClient.swift; sourceTree = "<group>"; };
+		9DEBD7F1E386956FE512E3D6 /* NotificationClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationClient.swift; sourceTree = "<group>"; };
 		9EA85C7AECFB312B3FB9D051 /* PrecioLuzAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrecioLuzAppApp.swift; sourceTree = "<group>"; };
 		A20AF13249077EB2D15ECE90 /* AppFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFeatureTests.swift; sourceTree = "<group>"; };
+		A2868808D917525D9B949780 /* ClientDependenciesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientDependenciesTests.swift; sourceTree = "<group>"; };
 		A349262256B13A6827F96952 /* PricesFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PricesFeature.swift; sourceTree = "<group>"; };
 		C43BF8A9E6F9D897404A6074 /* TCASmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCASmokeTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -45,7 +56,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				800D4B667AA0009EDF34F4A4 /* SQLiteData in Frameworks */,
+				800D4B667AA0009EDF34F4A4 /* ComposableArchitecture in Frameworks */,
+				693300BDC4A7882348CC27BB /* SQLiteData in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -81,6 +93,7 @@
 			isa = PBXGroup;
 			children = (
 				71088751C04036CD9D54835A /* App */,
+				C563F2CBC5E981184D00E1E6 /* Clients */,
 				C5FBB96D19C4A3102F3B2C86 /* Features */,
 			);
 			path = Sources;
@@ -119,6 +132,17 @@
 			path = App;
 			sourceTree = "<group>";
 		};
+		C563F2CBC5E981184D00E1E6 /* Clients */ = {
+			isa = PBXGroup;
+			children = (
+				98F488EF3222A15A96E4F3CF /* DateClient.swift */,
+				9DEBD7F1E386956FE512E3D6 /* NotificationClient.swift */,
+				8560ED2DC8C618B58A3BF47D /* PersistenceClient.swift */,
+				5CD7FDA5CB1305816A882113 /* PricingClient.swift */,
+			);
+			path = Clients;
+			sourceTree = "<group>";
+		};
 		C5FBB96D19C4A3102F3B2C86 /* Features */ = {
 			isa = PBXGroup;
 			children = (
@@ -134,6 +158,7 @@
 			isa = PBXGroup;
 			children = (
 				A20AF13249077EB2D15ECE90 /* AppFeatureTests.swift */,
+				A2868808D917525D9B949780 /* ClientDependenciesTests.swift */,
 				C43BF8A9E6F9D897404A6074 /* TCASmokeTests.swift */,
 			);
 			path = Tests;
@@ -163,6 +188,7 @@
 			);
 			name = PrecioLuzApp;
 			packageProductDependencies = (
+				C64AB47F534C3EF47DA37C60 /* ComposableArchitecture */,
 				4188B8C7C367C21C44A8C549 /* SQLiteData */,
 			);
 			productName = PrecioLuzApp;
@@ -231,8 +257,12 @@
 			files = (
 				E4A687F3008BBA0F8B3C409C /* AppFeature.swift in Sources */,
 				C38E3205CBA69E8FEEC1230F /* ChartFeature.swift in Sources */,
+				BE6F8B2F22DC95595232845A /* DateClient.swift in Sources */,
+				FFD909BEA040F73D5FEDDC2D /* NotificationClient.swift in Sources */,
+				0707733D9FC9E87DBB20DE2B /* PersistenceClient.swift in Sources */,
 				D4F2BDEAF0E519BD8DCB871B /* PrecioLuzAppApp.swift in Sources */,
 				9B13DE84E95AAB6D55816805 /* PricesFeature.swift in Sources */,
+				324A8B65E4B3AE6929DAC3AF /* PricingClient.swift in Sources */,
 				85ABD8BD485CCA4876B101A7 /* SettingsFeature.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -242,6 +272,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				32965E2DB2F87CDF4A850149 /* AppFeatureTests.swift in Sources */,
+				D5C9D8D8D1D9B4387E66B778 /* ClientDependenciesTests.swift in Sources */,
 				628CD71F5793AFE56AFA1109 /* TCASmokeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -502,6 +533,11 @@
 			productName = SQLiteData;
 		};
 		B05968D2E8CFF8E01B748541 /* ComposableArchitecture */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0FDEA251C6FA6D692292341D /* XCRemoteSwiftPackageReference "swift-composable-architecture" */;
+			productName = ComposableArchitecture;
+		};
+		C64AB47F534C3EF47DA37C60 /* ComposableArchitecture */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 0FDEA251C6FA6D692292341D /* XCRemoteSwiftPackageReference "swift-composable-architecture" */;
 			productName = ComposableArchitecture;

--- a/PrecioLuzApp.xcodeproj/project.pbxproj
+++ b/PrecioLuzApp.xcodeproj/project.pbxproj
@@ -10,11 +10,13 @@
 		0707733D9FC9E87DBB20DE2B /* PersistenceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8560ED2DC8C618B58A3BF47D /* PersistenceClient.swift */; };
 		324A8B65E4B3AE6929DAC3AF /* PricingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CD7FDA5CB1305816A882113 /* PricingClient.swift */; };
 		32965E2DB2F87CDF4A850149 /* AppFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20AF13249077EB2D15ECE90 /* AppFeatureTests.swift */; };
+		4C0BAE6A4CB9433F43182C37 /* DomainModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75905F6274FE9F8BFD18AA70 /* DomainModels.swift */; };
 		628CD71F5793AFE56AFA1109 /* TCASmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C43BF8A9E6F9D897404A6074 /* TCASmokeTests.swift */; };
 		693300BDC4A7882348CC27BB /* SQLiteData in Frameworks */ = {isa = PBXBuildFile; productRef = 4188B8C7C367C21C44A8C549 /* SQLiteData */; };
 		800D4B667AA0009EDF34F4A4 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = C64AB47F534C3EF47DA37C60 /* ComposableArchitecture */; };
 		85ABD8BD485CCA4876B101A7 /* SettingsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85CBEA5E1ECD0491F94E0DBA /* SettingsFeature.swift */; };
 		9B13DE84E95AAB6D55816805 /* PricesFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = A349262256B13A6827F96952 /* PricesFeature.swift */; };
+		9DF2CCB727E5BE82950696DA /* DomainModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2747995B05A5F06C74D942BF /* DomainModelsTests.swift */; };
 		BE6F8B2F22DC95595232845A /* DateClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F488EF3222A15A96E4F3CF /* DateClient.swift */; };
 		C38E3205CBA69E8FEEC1230F /* ChartFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC5C7E5F151FC11C56A3D19 /* ChartFeature.swift */; };
 		CE2C0DE70A00C8DB9F34406B /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = B05968D2E8CFF8E01B748541 /* ComposableArchitecture */; };
@@ -37,9 +39,11 @@
 /* Begin PBXFileReference section */
 		07E8C05629B788AE315B0D11 /* PrecioLuzAppTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = PrecioLuzAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1FC5C7E5F151FC11C56A3D19 /* ChartFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartFeature.swift; sourceTree = "<group>"; };
+		2747995B05A5F06C74D942BF /* DomainModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainModelsTests.swift; sourceTree = "<group>"; };
 		288DF63F4693A0161011B4A4 /* AppFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFeature.swift; sourceTree = "<group>"; };
 		5CD7FDA5CB1305816A882113 /* PricingClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PricingClient.swift; sourceTree = "<group>"; };
 		741F0D1CD612C8F05168C6B2 /* PrecioLuzApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = PrecioLuzApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		75905F6274FE9F8BFD18AA70 /* DomainModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainModels.swift; sourceTree = "<group>"; };
 		8560ED2DC8C618B58A3BF47D /* PersistenceClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceClient.swift; sourceTree = "<group>"; };
 		85CBEA5E1ECD0491F94E0DBA /* SettingsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsFeature.swift; sourceTree = "<group>"; };
 		98F488EF3222A15A96E4F3CF /* DateClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateClient.swift; sourceTree = "<group>"; };
@@ -94,6 +98,7 @@
 			children = (
 				71088751C04036CD9D54835A /* App */,
 				C563F2CBC5E981184D00E1E6 /* Clients */,
+				FC9E4DC28FEBF626F3076DB2 /* Domain */,
 				C5FBB96D19C4A3102F3B2C86 /* Features */,
 			);
 			path = Sources;
@@ -159,6 +164,7 @@
 			children = (
 				A20AF13249077EB2D15ECE90 /* AppFeatureTests.swift */,
 				A2868808D917525D9B949780 /* ClientDependenciesTests.swift */,
+				2747995B05A5F06C74D942BF /* DomainModelsTests.swift */,
 				C43BF8A9E6F9D897404A6074 /* TCASmokeTests.swift */,
 			);
 			path = Tests;
@@ -170,6 +176,14 @@
 				288DF63F4693A0161011B4A4 /* AppFeature.swift */,
 			);
 			path = AppFeature;
+			sourceTree = "<group>";
+		};
+		FC9E4DC28FEBF626F3076DB2 /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				75905F6274FE9F8BFD18AA70 /* DomainModels.swift */,
+			);
+			path = Domain;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -258,6 +272,7 @@
 				E4A687F3008BBA0F8B3C409C /* AppFeature.swift in Sources */,
 				C38E3205CBA69E8FEEC1230F /* ChartFeature.swift in Sources */,
 				BE6F8B2F22DC95595232845A /* DateClient.swift in Sources */,
+				4C0BAE6A4CB9433F43182C37 /* DomainModels.swift in Sources */,
 				FFD909BEA040F73D5FEDDC2D /* NotificationClient.swift in Sources */,
 				0707733D9FC9E87DBB20DE2B /* PersistenceClient.swift in Sources */,
 				D4F2BDEAF0E519BD8DCB871B /* PrecioLuzAppApp.swift in Sources */,
@@ -273,6 +288,7 @@
 			files = (
 				32965E2DB2F87CDF4A850149 /* AppFeatureTests.swift in Sources */,
 				D5C9D8D8D1D9B4387E66B778 /* ClientDependenciesTests.swift in Sources */,
+				9DF2CCB727E5BE82950696DA /* DomainModelsTests.swift in Sources */,
 				628CD71F5793AFE56AFA1109 /* TCASmokeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Clients/DateClient.swift
+++ b/Sources/Clients/DateClient.swift
@@ -1,0 +1,29 @@
+import ComposableArchitecture
+import Foundation
+
+struct DateClient: Sendable {
+  var now: @Sendable () -> Date
+  var calendar: @Sendable () -> Calendar
+  var timeZone: @Sendable () -> TimeZone
+}
+
+extension DateClient: DependencyKey {
+  static let liveValue = DateClient(
+    now: { Date() },
+    calendar: { Calendar(identifier: .gregorian) },
+    timeZone: { TimeZone(identifier: "Europe/Madrid") ?? .current }
+  )
+
+  static let testValue = DateClient(
+    now: { Date(timeIntervalSince1970: .zero) },
+    calendar: { Calendar(identifier: .gregorian) },
+    timeZone: { TimeZone(secondsFromGMT: .zero) ?? .current }
+  )
+}
+
+extension DependencyValues {
+  var dateClient: DateClient {
+    get { self[DateClient.self] }
+    set { self[DateClient.self] = newValue }
+  }
+}

--- a/Sources/Clients/NotificationClient.swift
+++ b/Sources/Clients/NotificationClient.swift
@@ -1,0 +1,44 @@
+import ComposableArchitecture
+import Foundation
+
+struct NotificationClient: Sendable {
+  var authorizationStatus: @Sendable () async -> AuthorizationStatus
+  var requestAuthorization: @Sendable () async throws -> Bool
+  var schedule: @Sendable (_ requests: [Request]) async throws -> Void
+}
+
+extension NotificationClient {
+  enum AuthorizationStatus: Equatable, Sendable {
+    case notDetermined
+    case denied
+    case authorized
+  }
+
+  struct Request: Equatable, Sendable {
+    var id: String
+    var title: String
+    var body: String
+    var triggerDate: Date
+  }
+}
+
+extension NotificationClient: DependencyKey {
+  static let liveValue = NotificationClient(
+    authorizationStatus: { .notDetermined },
+    requestAuthorization: { false },
+    schedule: { _ in }
+  )
+
+  static let testValue = NotificationClient(
+    authorizationStatus: { .authorized },
+    requestAuthorization: { true },
+    schedule: { _ in }
+  )
+}
+
+extension DependencyValues {
+  var notificationClient: NotificationClient {
+    get { self[NotificationClient.self] }
+    set { self[NotificationClient.self] = newValue }
+  }
+}

--- a/Sources/Clients/PersistenceClient.swift
+++ b/Sources/Clients/PersistenceClient.swift
@@ -1,0 +1,37 @@
+import ComposableArchitecture
+import Foundation
+
+struct PersistenceClient: Sendable {
+  var loadSnapshot: @Sendable (_ day: Date, _ timeZone: TimeZone) async throws -> DailySnapshot?
+  var saveSnapshot: @Sendable (_ snapshot: DailySnapshot) async throws -> Void
+  var pruneSnapshots: @Sendable (_ keepLastDays: Int) async throws -> Void
+}
+
+extension PersistenceClient {
+  struct DailySnapshot: Equatable, Sendable {
+    var dayStart: Date
+    var fetchedAt: Date
+    var hourlyPrices: [PricingClient.HourPrice]
+  }
+}
+
+extension PersistenceClient: DependencyKey {
+  static let liveValue = PersistenceClient(
+    loadSnapshot: { _, _ in nil },
+    saveSnapshot: { _ in },
+    pruneSnapshots: { _ in }
+  )
+
+  static let testValue = PersistenceClient(
+    loadSnapshot: { _, _ in nil },
+    saveSnapshot: { _ in },
+    pruneSnapshots: { _ in }
+  )
+}
+
+extension DependencyValues {
+  var persistenceClient: PersistenceClient {
+    get { self[PersistenceClient.self] }
+    set { self[PersistenceClient.self] = newValue }
+  }
+}

--- a/Sources/Clients/PricingClient.swift
+++ b/Sources/Clients/PricingClient.swift
@@ -1,0 +1,48 @@
+import ComposableArchitecture
+import Foundation
+
+struct PricingClient: Sendable {
+  var fetchDailyPrices: @Sendable (_ day: Date, _ timeZone: TimeZone) async throws -> [HourPrice]
+}
+
+extension PricingClient {
+  struct HourPrice: Equatable, Sendable {
+    var date: Date
+    var eurPerKWh: Double
+  }
+}
+
+extension PricingClient: DependencyKey {
+  static let liveValue = PricingClient { day, timeZone in
+    StubPricingModel.makeDailyPrices(for: day, timeZone: timeZone)
+  }
+
+  static let testValue = PricingClient { day, timeZone in
+    StubPricingModel.makeDailyPrices(for: day, timeZone: timeZone)
+  }
+}
+
+private enum StubPricingModel {
+  static let basePriceEURPerKWh = 0.10
+  static let hourlyStepEURPerKWh = 0.005
+  static let hourlyCount = 24
+
+  static func makeDailyPrices(for day: Date, timeZone: TimeZone) -> [PricingClient.HourPrice] {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = timeZone
+    let startOfDay = calendar.startOfDay(for: day)
+
+    return (0..<hourlyCount).map { hour in
+      let hourDate = calendar.date(byAdding: .hour, value: hour, to: startOfDay) ?? startOfDay
+      let price = basePriceEURPerKWh + Double(hour) * hourlyStepEURPerKWh
+      return PricingClient.HourPrice(date: hourDate, eurPerKWh: price)
+    }
+  }
+}
+
+extension DependencyValues {
+  var pricingClient: PricingClient {
+    get { self[PricingClient.self] }
+    set { self[PricingClient.self] = newValue }
+  }
+}

--- a/Sources/Domain/DailyPricingSnapshotPipeline.swift
+++ b/Sources/Domain/DailyPricingSnapshotPipeline.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+struct DailyPricingSnapshotPayload: Equatable, Sendable {
+    var dayStart: Date
+    var fetchedAt: Date
+    var hourlyPrices: [HourlyPrice]
+    var summary: PriceSummary?
+}
+
+enum DailyPricingSnapshotPipelineResult: Equatable, Sendable {
+    case cached(DailyPricingSnapshotPayload)
+    case failed
+    case fresh(DailyPricingSnapshotPayload)
+}
+
+struct DailyPricingSnapshotPipeline: Sendable {
+    private typealias Payload = DailyPricingSnapshotPayload
+    typealias PipelineResult = DailyPricingSnapshotPipelineResult
+    private typealias RawPrices = [PricingClient.HourPrice]
+    private static let retentionDays = 30
+
+    let dateClient: DateClient
+    let persistenceClient: PersistenceClient
+    let pricingClient: PricingClient
+
+    func load(for day: Date? = nil) async -> PipelineResult {
+        let now = dateClient.now()
+        let timeZone = dateClient.timeZone()
+        var calendar = dateClient.calendar()
+        calendar.timeZone = timeZone
+
+        let targetDay = day ?? now
+        let dayStart = calendar.startOfDay(for: targetDay)
+
+        do {
+            let rawHourlyPrices = try await pricingClient.fetchDailyPrices(dayStart, timeZone)
+            let payload = makePayload(
+                dayStart: dayStart,
+                fetchedAt: now,
+                now: now,
+                rawPrices: rawHourlyPrices,
+                calendar: calendar
+            )
+
+            try await persistenceClient.saveSnapshot(
+                .init(
+                    dayStart: dayStart,
+                    fetchedAt: now,
+                    hourlyPrices: rawHourlyPrices
+                )
+            )
+            try await persistenceClient.pruneSnapshots(Self.retentionDays)
+
+            return .fresh(payload)
+        } catch {
+            return await loadCachedResult(
+                dayStart: dayStart,
+                now: now,
+                timeZone: timeZone,
+                calendar: calendar
+            )
+        }
+    }
+
+    private func loadCachedResult(dayStart: Date, now: Date, timeZone: TimeZone, calendar: Calendar)
+    async -> PipelineResult {
+        do {
+            guard let snapshot = try await persistenceClient.loadSnapshot(dayStart, timeZone) else {
+                return .failed
+            }
+
+            let payload = makePayload(
+                dayStart: snapshot.dayStart,
+                fetchedAt: snapshot.fetchedAt,
+                now: now,
+                rawPrices: snapshot.hourlyPrices,
+                calendar: calendar
+            )
+            return .cached(payload)
+        } catch {
+            return .failed
+        }
+    }
+
+    private func makePayload(dayStart: Date, fetchedAt: Date, now: Date, rawPrices: RawPrices, calendar: Calendar)
+    -> Payload {
+        let hourlyPrices = HourlyPriceClassifier.classify(rawPrices, calendar: calendar)
+        let summary = DailyPriceSummaryBuilder.makeSummary(from: hourlyPrices, now: now, calendar: calendar)
+        return DailyPricingSnapshotPayload(
+            dayStart: dayStart,
+            fetchedAt: fetchedAt,
+            hourlyPrices: hourlyPrices,
+            summary: summary
+        )
+    }
+}

--- a/Sources/Domain/DailyPricingSnapshotPipeline.swift
+++ b/Sources/Domain/DailyPricingSnapshotPipeline.swift
@@ -32,26 +32,9 @@ struct DailyPricingSnapshotPipeline: Sendable {
         let targetDay = day ?? now
         let dayStart = calendar.startOfDay(for: targetDay)
 
+        let rawHourlyPrices: RawPrices
         do {
-            let rawHourlyPrices = try await pricingClient.fetchDailyPrices(dayStart, timeZone)
-            let payload = makePayload(
-                dayStart: dayStart,
-                fetchedAt: now,
-                now: now,
-                rawPrices: rawHourlyPrices,
-                calendar: calendar
-            )
-
-            try await persistenceClient.saveSnapshot(
-                .init(
-                    dayStart: dayStart,
-                    fetchedAt: now,
-                    hourlyPrices: rawHourlyPrices
-                )
-            )
-            try await persistenceClient.pruneSnapshots(Self.retentionDays)
-
-            return .fresh(payload)
+            rawHourlyPrices = try await pricingClient.fetchDailyPrices(dayStart, timeZone)
         } catch {
             return await loadCachedResult(
                 dayStart: dayStart,
@@ -60,6 +43,16 @@ struct DailyPricingSnapshotPipeline: Sendable {
                 calendar: calendar
             )
         }
+
+        let payload = makePayload(
+            dayStart: dayStart,
+            fetchedAt: now,
+            now: now,
+            rawPrices: rawHourlyPrices,
+            calendar: calendar
+        )
+        await persistSnapshot(dayStart: dayStart, fetchedAt: now, rawPrices: rawHourlyPrices)
+        return .fresh(payload)
     }
 
     private func loadCachedResult(dayStart: Date, now: Date, timeZone: TimeZone, calendar: Calendar)
@@ -92,5 +85,19 @@ struct DailyPricingSnapshotPipeline: Sendable {
             hourlyPrices: hourlyPrices,
             summary: summary
         )
+    }
+
+    private func persistSnapshot(dayStart: Date, fetchedAt: Date, rawPrices: RawPrices) async {
+        do {
+            try await persistenceClient.saveSnapshot(
+                .init(
+                    dayStart: dayStart,
+                    fetchedAt: fetchedAt,
+                    hourlyPrices: rawPrices
+                )
+            )
+            try await persistenceClient.pruneSnapshots(Self.retentionDays)
+        } catch {
+        }
     }
 }

--- a/Sources/Domain/DomainModels.swift
+++ b/Sources/Domain/DomainModels.swift
@@ -1,0 +1,201 @@
+import Foundation
+
+enum Daypart: String, CaseIterable, Equatable, Sendable {
+    case overnight
+    case morning
+    case afternoon
+    case night
+
+    static func from(date: Date, calendar: Calendar) -> Self {
+        let hour = calendar.component(.hour, from: date)
+        switch hour {
+        case 0...5:
+            return .overnight
+        case 6...11:
+            return .morning
+        case 12...17:
+            return .afternoon
+        default:
+            return .night
+        }
+    }
+}
+
+enum PriceClassification: Equatable, Sendable {
+    case cheap
+    case expensive
+    case mid
+}
+
+struct HourlyPrice: Equatable, Sendable {
+    var classification: PriceClassification
+    var date: Date
+    var daypart: Daypart
+    var eurPerKWh: Double
+
+    init(classification: PriceClassification, date: Date, daypart: Daypart, eurPerKWh: Double) {
+        self.classification = classification
+        self.date = date
+        self.daypart = daypart
+        self.eurPerKWh = eurPerKWh
+    }
+
+    init(classification: PriceClassification, raw: PricingClient.HourPrice, calendar: Calendar) {
+        self.init(
+            classification: classification,
+            date: raw.date,
+            daypart: Daypart.from(date: raw.date, calendar: calendar),
+            eurPerKWh: raw.eurPerKWh
+        )
+    }
+
+    func isSameHour(as date: Date, calendar: Calendar) -> Bool {
+        calendar.isDate(self.date, equalTo: date, toGranularity: .hour)
+    }
+}
+
+struct PriceSummary: Equatable, Sendable {
+    var average: Double
+    var current: HourlyPrice?
+    var maximum: Double
+    var maximumHour: Date
+    var minimum: Double
+    var minimumHour: Date
+
+    static func from(_ prices: [HourlyPrice]) -> Self? {
+        guard let first = prices.first else { return nil }
+
+        let average = prices.map(\.eurPerKWh).reduce(0, +) / Double(prices.count)
+        let maximumEntry = prices.max { $0.eurPerKWh < $1.eurPerKWh } ?? first
+        let minimumEntry = prices.min { $0.eurPerKWh < $1.eurPerKWh } ?? first
+
+        return Self(
+            average: average,
+            current: nil,
+            maximum: maximumEntry.eurPerKWh,
+            maximumHour: maximumEntry.date,
+            minimum: minimumEntry.eurPerKWh,
+            minimumHour: minimumEntry.date
+        )
+    }
+}
+
+struct AppliancePreset: Equatable, Sendable {
+    enum Kind: String, Equatable, Sendable {
+        case airConditioner
+        case clothesDryer
+        case dishwasher
+        case electricHeater
+        case electricVehicle
+        case inductionCooktop
+        case oven
+        case washingMachine
+        case waterHeater
+    }
+
+    var displayName: String
+    var kind: Kind
+    var powerKW: Double
+    var shortDescription: String
+    var symbolName: String
+}
+
+struct CostCalculation: Equatable, Sendable {
+    var durationHours: Double
+    var estimatedCostEUR: Double
+    var preset: AppliancePreset
+    var priceAppliedEURPerKWh: Double
+    var selectedHour: HourlyPrice
+}
+
+struct NotificationSettings: Equatable, Sendable {
+    var customThresholdEnabled: Bool
+    var customThresholdEURPerKWh: Double?
+    var notificationsEnabled: Bool
+    var notifyDailyMaximum: Bool
+    var notifyDailyMinimum: Bool
+}
+
+enum HourlyPriceClassifier {
+    private struct IndexedPrice {
+        let index: Int
+        let price: PricingClient.HourPrice
+    }
+
+    static func classify(_ prices: [PricingClient.HourPrice], calendar: Calendar) -> [HourlyPrice] {
+        guard !prices.isEmpty else { return [] }
+
+        let indexedPrices = prices.enumerated().map {
+            IndexedPrice(index: $0.offset, price: $0.element)
+        }
+        let (cheapIndices, expensiveIndices) = bucketIndices(for: indexedPrices)
+
+        return indexedPrices.map { entry in
+            let classification: PriceClassification
+            if cheapIndices.contains(entry.index) {
+                classification = .cheap
+            } else if expensiveIndices.contains(entry.index) {
+                classification = .expensive
+            } else {
+                classification = .mid
+            }
+
+            return HourlyPrice(
+                classification: classification,
+                raw: entry.price,
+                calendar: calendar
+            )
+        }
+    }
+
+    private static func bucketIndices(for prices: [IndexedPrice]) -> (cheap: Set<Int>, expensive: Set<Int>) {
+        let count = prices.count
+        guard count > 1 else { return ([], []) }
+
+        let sorted = prices.sorted {
+            if $0.price.eurPerKWh == $1.price.eurPerKWh {
+                return $0.price.date < $1.price.date
+            }
+            return $0.price.eurPerKWh < $1.price.eurPerKWh
+        }
+
+        let baseSize = count / 3
+        let cheapSize = max(1, baseSize)
+        let expensiveSize = max(1, baseSize)
+
+        let cheap = Set(sorted.prefix(cheapSize).map(\.index))
+        let expensive = Set(sorted.suffix(expensiveSize).map(\.index))
+        return (cheap, expensive)
+    }
+}
+
+enum DailyPriceSummaryBuilder {
+    static func makeSummary(from prices: [HourlyPrice]) -> PriceSummary? {
+        PriceSummary.from(prices)
+    }
+
+    static func makeSummary(from prices: [HourlyPrice], now: Date, calendar: Calendar) -> PriceSummary? {
+        PriceSummary.from(prices)?.withCurrent(from: prices, matching: now, calendar: calendar)
+    }
+}
+
+enum ApplianceCostEstimator {
+    static func estimate(durationHours: Double, preset: AppliancePreset, selectedHour: HourlyPrice) -> CostCalculation {
+        let estimatedCostEUR = selectedHour.eurPerKWh * preset.powerKW * durationHours
+        return CostCalculation(
+            durationHours: durationHours,
+            estimatedCostEUR: estimatedCostEUR,
+            preset: preset,
+            priceAppliedEURPerKWh: selectedHour.eurPerKWh,
+            selectedHour: selectedHour
+        )
+    }
+}
+
+private extension PriceSummary {
+    func withCurrent(from prices: [HourlyPrice], matching date: Date, calendar: Calendar) -> Self {
+        var summary = self
+        summary.current = prices.first { $0.isSameHour(as: date, calendar: calendar) }
+        return summary
+    }
+}

--- a/Tests/AppFeatureTests.swift
+++ b/Tests/AppFeatureTests.swift
@@ -1,11 +1,12 @@
-import XCTest
+import Testing
 
 @testable import PrecioLuzApp
 
-final class AppFeatureTests: XCTestCase {
-  func testTabSymbolsAreConfigured() {
-    XCTAssertEqual(AppTab.prices.systemImage, "eurosign.circle")
-    XCTAssertEqual(AppTab.chart.systemImage, "chart.xyaxis.line")
-    XCTAssertEqual(AppTab.settings.systemImage, "gearshape")
+struct AppFeatureTests {
+  @Test("App tabs expose expected SF Symbols")
+  func tabSymbolsAreConfigured() {
+    #expect(AppTab.prices.systemImage == "eurosign.circle")
+    #expect(AppTab.chart.systemImage == "chart.xyaxis.line")
+    #expect(AppTab.settings.systemImage == "gearshape")
   }
 }

--- a/Tests/ClientDependenciesTests.swift
+++ b/Tests/ClientDependenciesTests.swift
@@ -1,0 +1,40 @@
+import ComposableArchitecture
+import Foundation
+import Testing
+
+@testable import PrecioLuzApp
+
+struct ClientDependenciesTests {
+  @Test("PricingClient testValue returns 24 deterministic hourly prices")
+  func pricingClientTestValueProduces24HourlyPrices() async throws {
+    let day = Date(timeIntervalSince1970: 1_700_000_000)
+      let prices = try await PricingClient.testValue.fetchDailyPrices(day, TimeZone(secondsFromGMT: .zero)!)
+
+    #expect(prices.count == 24)
+    let firstPrice = try #require(prices.first?.eurPerKWh)
+    let lastPrice = try #require(prices.last?.eurPerKWh)
+    let epsilon = 0.000_001
+    #expect(abs(firstPrice - 0.10) < epsilon)
+    #expect(abs(lastPrice - 0.215) < epsilon)
+  }
+
+  @Test("DateClient testValue returns deterministic now and timezone")
+  func dateClientTestValueIsDeterministic() {
+      #expect(DateClient.testValue.now() == Date(timeIntervalSince1970: .zero))
+      #expect(DateClient.testValue.timeZone() == TimeZone(secondsFromGMT: .zero))
+  }
+
+  @Test("NotificationClient testValue reports authorized status")
+  func notificationClientTestValueIsAuthorized() async {
+    let status = await NotificationClient.testValue.authorizationStatus()
+    #expect(status == .authorized)
+  }
+
+  @Test("PersistenceClient testValue returns no snapshot by default")
+  func persistenceClientTestValueReturnsNoSnapshot() async throws {
+    let day = Date(timeIntervalSince1970: 1_700_000_000)
+    let snapshot = try await PersistenceClient.testValue.loadSnapshot(day, .current)
+
+    #expect(snapshot == nil)
+  }
+}

--- a/Tests/DailyPricingSnapshotPipelineTests.swift
+++ b/Tests/DailyPricingSnapshotPipelineTests.swift
@@ -1,0 +1,164 @@
+import Foundation
+import Testing
+
+@testable import PrecioLuzApp
+
+struct DailyPricingSnapshotPipelineTests {
+  @Test("Pipeline returns fresh data, persists snapshot and prunes retention window")
+  func freshResultPersistsAndPrunes() async throws {
+    let recorder = PersistenceRecorder()
+    let now = Date(timeIntervalSince1970: 1_700_000_000)
+    let dateClient = makeDateClient(now: now)
+    let timeZone = dateClient.timeZone()
+    var calendar = dateClient.calendar()
+    calendar.timeZone = timeZone
+    let dayStart = calendar.startOfDay(for: now)
+    let rawPrices = makeRawPrices(dayStart: dayStart, timeZone: timeZone)
+
+    let pricingClient = PricingClient { _, _ in rawPrices }
+    let persistenceClient = PersistenceClient(
+      loadSnapshot: { _, _ in
+        await recorder.recordLoad()
+        return nil
+      },
+      saveSnapshot: { snapshot in
+        await recorder.recordSave(snapshot)
+      },
+      pruneSnapshots: { keepLastDays in
+        await recorder.recordPrune(keepLastDays)
+      }
+    )
+    let pipeline = DailyPricingSnapshotPipeline(
+      dateClient: dateClient,
+      persistenceClient: persistenceClient,
+      pricingClient: pricingClient
+    )
+
+    let result = await pipeline.load()
+
+    guard case let .fresh(payload) = result else {
+      Issue.record("Expected fresh result.")
+      return
+    }
+
+    #expect(payload.dayStart == dayStart)
+    #expect(payload.fetchedAt == now)
+    #expect(payload.hourlyPrices.count == rawPrices.count)
+    #expect(payload.summary != nil)
+    #expect(await recorder.loadCount == 0)
+    #expect(await recorder.savedSnapshots.count == 1)
+    #expect(await recorder.pruneCalls == [30])
+  }
+
+  @Test("Pipeline falls back to cached snapshot when fetch fails")
+  func cachedFallbackWhenFetchFails() async throws {
+    let recorder = PersistenceRecorder()
+    let now = Date(timeIntervalSince1970: 1_700_000_000)
+    let dateClient = makeDateClient(now: now)
+    let timeZone = dateClient.timeZone()
+    var calendar = dateClient.calendar()
+    calendar.timeZone = timeZone
+    let dayStart = calendar.startOfDay(for: now)
+    let cachedPrices = makeRawPrices(dayStart: dayStart, timeZone: timeZone)
+    let cachedSnapshot = PersistenceClient.DailySnapshot(
+      dayStart: dayStart,
+      fetchedAt: now.addingTimeInterval(-3600),
+      hourlyPrices: cachedPrices
+    )
+
+    enum TestError: Error { case offline }
+
+    let pricingClient = PricingClient { _, _ in throw TestError.offline }
+    let persistenceClient = PersistenceClient(
+      loadSnapshot: { _, _ in
+        await recorder.recordLoad()
+        return cachedSnapshot
+      },
+      saveSnapshot: { snapshot in
+        await recorder.recordSave(snapshot)
+      },
+      pruneSnapshots: { keepLastDays in
+        await recorder.recordPrune(keepLastDays)
+      }
+    )
+    let pipeline = DailyPricingSnapshotPipeline(
+      dateClient: dateClient,
+      persistenceClient: persistenceClient,
+      pricingClient: pricingClient
+    )
+
+    let result = await pipeline.load()
+
+    guard case let .cached(payload) = result else {
+      Issue.record("Expected cached result.")
+      return
+    }
+
+    #expect(payload.dayStart == cachedSnapshot.dayStart)
+    #expect(payload.fetchedAt == cachedSnapshot.fetchedAt)
+    #expect(payload.hourlyPrices.count == cachedPrices.count)
+    #expect(await recorder.loadCount == 1)
+    #expect(await recorder.savedSnapshots.isEmpty)
+    #expect(await recorder.pruneCalls.isEmpty)
+  }
+
+  @Test("Pipeline returns failed when fetch and cache both fail")
+  func failedWhenNoCacheAvailable() async {
+    let now = Date(timeIntervalSince1970: 1_700_000_000)
+    let dateClient = makeDateClient(now: now)
+
+    enum TestError: Error { case offline }
+
+    let pricingClient = PricingClient { _, _ in throw TestError.offline }
+    let persistenceClient = PersistenceClient(
+      loadSnapshot: { _, _ in nil },
+      saveSnapshot: { _ in },
+      pruneSnapshots: { _ in }
+    )
+    let pipeline = DailyPricingSnapshotPipeline(
+      dateClient: dateClient,
+      persistenceClient: persistenceClient,
+      pricingClient: pricingClient
+    )
+
+    let result = await pipeline.load()
+    #expect(result == .failed)
+  }
+
+  private func makeDateClient(now: Date) -> DateClient {
+    DateClient(
+      now: { now },
+      calendar: { Calendar(identifier: .gregorian) },
+      timeZone: { TimeZone(secondsFromGMT: .zero) ?? .current }
+    )
+  }
+
+  private func makeRawPrices(dayStart: Date, timeZone: TimeZone) -> [PricingClient.HourPrice] {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = timeZone
+
+    return (0..<24).compactMap { hour in
+      guard let date = calendar.date(byAdding: .hour, value: hour, to: dayStart) else { return nil }
+      let price = 0.10 + (Double(hour) * 0.01)
+      return .init(date: date, eurPerKWh: price)
+    }
+  }
+}
+
+private actor PersistenceRecorder {
+  private(set) var loadCount = 0
+  private(set) var pruneCalls: [Int] = []
+  private(set) var savedSnapshots: [PersistenceClient.DailySnapshot] = []
+
+  func recordLoad() {
+    loadCount += 1
+  }
+
+  func recordPrune(_ keepLastDays: Int) {
+    pruneCalls.append(keepLastDays)
+  }
+
+  func recordSave(_ snapshot: PersistenceClient.DailySnapshot) {
+    savedSnapshots.append(snapshot)
+  }
+}

--- a/Tests/DailyPricingSnapshotPipelineTests.swift
+++ b/Tests/DailyPricingSnapshotPipelineTests.swift
@@ -125,6 +125,49 @@ struct DailyPricingSnapshotPipelineTests {
     #expect(result == .failed)
   }
 
+  @Test("Pipeline still returns fresh when persistence operations fail")
+  func persistenceFailuresDoNotPreventFreshResult() async throws {
+    enum TestError: Error { case diskFailure }
+
+    let recorder = PersistenceRecorder()
+    let now = Date(timeIntervalSince1970: 1_700_000_000)
+    let dateClient = makeDateClient(now: now)
+    let timeZone = dateClient.timeZone()
+    var calendar = dateClient.calendar()
+    calendar.timeZone = timeZone
+    let dayStart = calendar.startOfDay(for: now)
+    let rawPrices = makeRawPrices(dayStart: dayStart, timeZone: timeZone)
+
+    let pricingClient = PricingClient { _, _ in rawPrices }
+    let persistenceClient = PersistenceClient(
+      loadSnapshot: { _, _ in
+        await recorder.recordLoad()
+        return nil
+      },
+      saveSnapshot: { _ in
+        throw TestError.diskFailure
+      },
+      pruneSnapshots: { _ in
+        throw TestError.diskFailure
+      }
+    )
+    let pipeline = DailyPricingSnapshotPipeline(
+      dateClient: dateClient,
+      persistenceClient: persistenceClient,
+      pricingClient: pricingClient
+    )
+
+    let result = await pipeline.load()
+    guard case let .fresh(payload) = result else {
+      Issue.record("Expected fresh result despite persistence failures.")
+      return
+    }
+
+    #expect(payload.dayStart == dayStart)
+    #expect(payload.hourlyPrices.count == rawPrices.count)
+    #expect(await recorder.loadCount == 0)
+  }
+
   private func makeDateClient(now: Date) -> DateClient {
     DateClient(
       now: { now },

--- a/Tests/DomainModelsTests.swift
+++ b/Tests/DomainModelsTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Testing
+
+@testable import PrecioLuzApp
+
+struct DomainModelsTests {
+  @Test("Daypart maps hour ranges correctly")
+  func daypartMapping() throws {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+    let day = Date(timeIntervalSince1970: 1_700_000_000)
+    let start = calendar.startOfDay(for: day)
+
+    let overnight = try #require(calendar.date(byAdding: .hour, value: 1, to: start))
+    let morning = try #require(calendar.date(byAdding: .hour, value: 7, to: start))
+    let afternoon = try #require(calendar.date(byAdding: .hour, value: 13, to: start))
+    let night = try #require(calendar.date(byAdding: .hour, value: 20, to: start))
+
+    #expect(Daypart.from(date: overnight, calendar: calendar) == .overnight)
+    #expect(Daypart.from(date: morning, calendar: calendar) == .morning)
+    #expect(Daypart.from(date: afternoon, calendar: calendar) == .afternoon)
+    #expect(Daypart.from(date: night, calendar: calendar) == .night)
+  }
+
+  @Test("Classification uses stable terciles with deterministic tie-breaking by date")
+  func stableTercileClassification() throws {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+    let day = Date(timeIntervalSince1970: 1_700_000_000)
+    let start = calendar.startOfDay(for: day)
+
+    let raw: [PricingClient.HourPrice] = [
+      .init(date: try #require(calendar.date(byAdding: .hour, value: 0, to: start)), eurPerKWh: 0.20),
+      .init(date: try #require(calendar.date(byAdding: .hour, value: 1, to: start)), eurPerKWh: 0.10),
+      .init(date: try #require(calendar.date(byAdding: .hour, value: 2, to: start)), eurPerKWh: 0.20),
+      .init(date: try #require(calendar.date(byAdding: .hour, value: 3, to: start)), eurPerKWh: 0.30),
+      .init(date: try #require(calendar.date(byAdding: .hour, value: 4, to: start)), eurPerKWh: 0.10),
+      .init(date: try #require(calendar.date(byAdding: .hour, value: 5, to: start)), eurPerKWh: 0.30)
+    ]
+
+    let classified = HourlyPriceClassifier.classify(raw, calendar: calendar)
+
+    #expect(classified.count == 6)
+    #expect(classified[1].classification == .cheap)
+    #expect(classified[4].classification == .cheap)
+    #expect(classified[0].classification == .mid)
+    #expect(classified[2].classification == .mid)
+    #expect(classified[3].classification == .expensive)
+    #expect(classified[5].classification == .expensive)
+  }
+
+  @Test("Classification handles small collections without arbitrary empty buckets")
+  func smallCollectionClassification() throws {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+    let day = Date(timeIntervalSince1970: 1_700_000_000)
+    let start = calendar.startOfDay(for: day)
+
+    let twoHours: [PricingClient.HourPrice] = [
+      .init(date: try #require(calendar.date(byAdding: .hour, value: 0, to: start)), eurPerKWh: 0.30),
+      .init(date: try #require(calendar.date(byAdding: .hour, value: 1, to: start)), eurPerKWh: 0.10)
+    ]
+
+    let oneHour: [PricingClient.HourPrice] = [
+      .init(date: try #require(calendar.date(byAdding: .hour, value: 2, to: start)), eurPerKWh: 0.20)
+    ]
+
+    let classifiedTwo = HourlyPriceClassifier.classify(twoHours, calendar: calendar)
+    let classifiedOne = HourlyPriceClassifier.classify(oneHour, calendar: calendar)
+
+    #expect(classifiedTwo.count == 2)
+    #expect(classifiedTwo[0].classification == .expensive)
+    #expect(classifiedTwo[1].classification == .cheap)
+    #expect(classifiedOne.count == 1)
+    #expect(classifiedOne[0].classification == .mid)
+  }
+
+  @Test("Daily summary computes current, average, minimum and maximum")
+  func dailySummary() throws {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+    let day = Date(timeIntervalSince1970: 1_700_000_000)
+    let start = calendar.startOfDay(for: day)
+
+    let raw: [PricingClient.HourPrice] = [
+      .init(date: try #require(calendar.date(byAdding: .hour, value: 0, to: start)), eurPerKWh: 0.10),
+      .init(date: try #require(calendar.date(byAdding: .hour, value: 1, to: start)), eurPerKWh: 0.20),
+      .init(date: try #require(calendar.date(byAdding: .hour, value: 2, to: start)), eurPerKWh: 0.30)
+    ]
+
+    let classified = HourlyPriceClassifier.classify(raw, calendar: calendar)
+    let now = try #require(calendar.date(byAdding: .hour, value: 1, to: start))
+    let summary = try #require(
+      DailyPriceSummaryBuilder.makeSummary(from: classified, now: now, calendar: calendar)
+    )
+
+    #expect(summary.current?.eurPerKWh == 0.20)
+    #expect(summary.minimum == 0.10)
+    #expect(summary.maximum == 0.30)
+    #expect(summary.minimumHour == raw[0].date)
+    #expect(summary.maximumHour == raw[2].date)
+    let epsilon = 0.000_001
+    #expect(abs(summary.average - 0.20) < epsilon)
+  }
+
+  @Test("Cost formula multiplies price by power and duration")
+  func costFormula() {
+    let selectedHour = HourlyPrice(
+      classification: .mid,
+      date: Date(timeIntervalSince1970: 0),
+      daypart: .morning,
+      eurPerKWh: 0.25
+    )
+    let preset = AppliancePreset(
+      displayName: "Lavadora",
+      kind: .washingMachine,
+      powerKW: 1.8,
+      shortDescription: "Eco cycle",
+      symbolName: "washer"
+    )
+
+    let calculation = ApplianceCostEstimator.estimate(
+      durationHours: 2.0,
+      preset: preset,
+      selectedHour: selectedHour
+    )
+
+    let epsilon = 0.000_001
+    #expect(abs(calculation.estimatedCostEUR - 0.9) < epsilon)
+    #expect(calculation.priceAppliedEURPerKWh == 0.25)
+  }
+}

--- a/Tests/Issue5AcceptanceTests.swift
+++ b/Tests/Issue5AcceptanceTests.swift
@@ -1,0 +1,179 @@
+import Foundation
+import Testing
+
+@testable import PrecioLuzApp
+
+struct Issue5AcceptanceTests {
+  @Test("Acceptance #5: fresh snapshot integrates derived values, cost and retention policy")
+  func freshSnapshotIntegration() async throws {
+    let recorder = AcceptancePipelineRecorder()
+    let now = Date(timeIntervalSince1970: 1_700_000_000)
+    let dateClient = makeDateClient(now: now)
+    let timeZone = dateClient.timeZone()
+    var calendar = dateClient.calendar()
+    calendar.timeZone = timeZone
+    let dayStart = calendar.startOfDay(for: now)
+    let rawPrices = makeHourlyPrices(dayStart: dayStart, timeZone: timeZone)
+    let persistenceClient = PersistenceClient(
+      loadSnapshot: { _, _ in
+        await recorder.recordLoad()
+        return nil
+      },
+      saveSnapshot: { snapshot in
+        await recorder.recordSave(snapshot)
+      },
+      pruneSnapshots: { keepLastDays in
+        await recorder.recordPrune(keepLastDays)
+      }
+    )
+    let pricingClient = PricingClient { _, _ in rawPrices }
+    let pipeline = DailyPricingSnapshotPipeline(
+      dateClient: dateClient,
+      persistenceClient: persistenceClient,
+      pricingClient: pricingClient
+    )
+
+    let result = await pipeline.load()
+    guard case let .fresh(payload) = result else {
+      Issue.record("Expected fresh result.")
+      return
+    }
+
+    let currentHour = try #require(payload.summary?.current)
+    let preset = AppliancePreset(
+      displayName: "Dishwasher",
+      kind: .dishwasher,
+      powerKW: 1.4,
+      shortDescription: "Standard cycle",
+      symbolName: "dishwasher"
+    )
+    let cost = ApplianceCostEstimator.estimate(durationHours: 1.5, preset: preset, selectedHour: currentHour)
+    let expectedCost = currentHour.eurPerKWh * preset.powerKW * 1.5
+    let epsilon = 0.000_001
+
+    #expect(payload.hourlyPrices.count == 24)
+    #expect(payload.summary != nil)
+    #expect(abs(cost.estimatedCostEUR - expectedCost) < epsilon)
+    #expect(await recorder.loadCount == 0)
+    #expect(await recorder.savedSnapshots.count == 1)
+    #expect(await recorder.pruneCalls == [30])
+  }
+
+  @Test("Acceptance #5: offline behavior uses cache and fails when cache is missing")
+  func offlineBehavior() async {
+    let recorder = AcceptancePipelineRecorder()
+    let now = Date(timeIntervalSince1970: 1_700_000_000)
+    let dateClient = makeDateClient(now: now)
+    let timeZone = dateClient.timeZone()
+    var calendar = dateClient.calendar()
+    calendar.timeZone = timeZone
+    let dayStart = calendar.startOfDay(for: now)
+    let cachedSnapshot = PersistenceClient.DailySnapshot(
+      dayStart: dayStart,
+      fetchedAt: now.addingTimeInterval(-3600),
+      hourlyPrices: makeHourlyPrices(dayStart: dayStart, timeZone: timeZone)
+    )
+
+    await verifyCachedFallback(
+      cachedSnapshot: cachedSnapshot,
+      dateClient: dateClient,
+      dayStart: dayStart,
+      recorder: recorder
+    )
+    await verifyOfflineFailureWithoutCache(dateClient: dateClient)
+  }
+
+  private func makeDateClient(now: Date) -> DateClient {
+    DateClient(
+      now: { now },
+      calendar: { Calendar(identifier: .gregorian) },
+      timeZone: { TimeZone(secondsFromGMT: .zero) ?? .current }
+    )
+  }
+
+  private func makeHourlyPrices(dayStart: Date, timeZone: TimeZone) -> [PricingClient.HourPrice] {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = timeZone
+
+    return (0..<24).compactMap { hour in
+      guard let date = calendar.date(byAdding: .hour, value: hour, to: dayStart) else { return nil }
+      return .init(date: date, eurPerKWh: 0.10 + (Double(hour) * 0.01))
+    }
+  }
+
+  private func verifyCachedFallback(
+    cachedSnapshot: PersistenceClient.DailySnapshot,
+    dateClient: DateClient,
+    dayStart: Date,
+    recorder: AcceptancePipelineRecorder
+  ) async {
+    enum TestError: Error { case offline }
+
+    let cachedPersistence = PersistenceClient(
+      loadSnapshot: { _, _ in
+        await recorder.recordLoad()
+        return cachedSnapshot
+      },
+      saveSnapshot: { snapshot in
+        await recorder.recordSave(snapshot)
+      },
+      pruneSnapshots: { keepLastDays in
+        await recorder.recordPrune(keepLastDays)
+      }
+    )
+    let failingPricing = PricingClient { _, _ in throw TestError.offline }
+    let cachedPipeline = DailyPricingSnapshotPipeline(
+      dateClient: dateClient,
+      persistenceClient: cachedPersistence,
+      pricingClient: failingPricing
+    )
+    let cachedResult = await cachedPipeline.load()
+
+    guard case let .cached(payload) = cachedResult else {
+      Issue.record("Expected cached result.")
+      return
+    }
+
+    #expect(payload.dayStart == dayStart)
+    #expect(payload.summary != nil)
+    #expect(await recorder.loadCount == 1)
+    #expect(await recorder.savedSnapshots.isEmpty)
+    #expect(await recorder.pruneCalls.isEmpty)
+  }
+
+  private func verifyOfflineFailureWithoutCache(dateClient: DateClient) async {
+    enum TestError: Error { case offline }
+
+    let emptyPersistence = PersistenceClient(
+      loadSnapshot: { _, _ in nil },
+      saveSnapshot: { _ in },
+      pruneSnapshots: { _ in }
+    )
+    let failingPricing = PricingClient { _, _ in throw TestError.offline }
+    let failedPipeline = DailyPricingSnapshotPipeline(
+      dateClient: dateClient,
+      persistenceClient: emptyPersistence,
+      pricingClient: failingPricing
+    )
+
+    #expect(await failedPipeline.load() == .failed)
+  }
+}
+
+private actor AcceptancePipelineRecorder {
+  private(set) var loadCount = 0
+  private(set) var pruneCalls: [Int] = []
+  private(set) var savedSnapshots: [PersistenceClient.DailySnapshot] = []
+
+  func recordLoad() {
+    loadCount += 1
+  }
+
+  func recordPrune(_ keepLastDays: Int) {
+    pruneCalls.append(keepLastDays)
+  }
+
+  func recordSave(_ snapshot: PersistenceClient.DailySnapshot) {
+    savedSnapshots.append(snapshot)
+  }
+}

--- a/Tests/TCASmokeTests.swift
+++ b/Tests/TCASmokeTests.swift
@@ -1,5 +1,5 @@
 import ComposableArchitecture
-import XCTest
+import Testing
 
 private struct CounterFeature: Reducer {
   struct State: Equatable {
@@ -21,9 +21,10 @@ private struct CounterFeature: Reducer {
   }
 }
 
-@MainActor
-final class TCASmokeTests: XCTestCase {
-  func testIncrement() async {
+struct TCASmokeTests {
+  @MainActor
+  @Test("CounterFeature increments count after increment action")
+  func increment() async {
     let store = TestStore(initialState: CounterFeature.State()) {
       CounterFeature()
     }

--- a/docs/codex-project-prompt.md
+++ b/docs/codex-project-prompt.md
@@ -27,6 +27,12 @@ Documentos a revisar:
 - docs/ui-direction.md (si aplica)
 </task_context>
 
+<preflight_sync>
+- Si estás en `main`, ejecuta `git pull --ff-only origin main`.
+- Si estás en feature branch, ejecuta `git fetch origin` y confirma alineación/base contra `origin/main`.
+- Si falla la sincronización, no implementes sobre estado desactualizado; deja el bloqueo explícito.
+</preflight_sync>
+
 <execution_focus>
 - Limita el cambio al alcance pedido.
 - No toques archivos no relacionados.

--- a/docs/engineering-rules.md
+++ b/docs/engineering-rules.md
@@ -139,6 +139,10 @@ Este documento convierte el marco de `AGENTS.md` en comportamiento técnico conc
 - No mergear trabajo directamente en `main`.
 - Cada feature debe llegar a `main` a través de una `Pull Request`.
 - El título y la descripción de la `Pull Request` deben estar en inglés.
+- Gestión de comentarios de review en PR (obligatorio):
+  - responder siempre a cada comentario de review con el contexto del cambio aplicado o la justificación técnica;
+  - tras aplicar el fix, marcar el hilo como resuelto;
+  - no dejar comentarios accionables sin respuesta ni hilos abiertos por omisión.
 - Si la `Pull Request` contiene código, el CI mínimo en `GitHub Actions` debe ejecutar al menos `build` y tests, y ambos deben estar en verde antes del merge.
 - Si la `Pull Request` es solo documental, no exige `build` Xcode, pero sí debe superar los checks documentales o de formato que existan.
 - Si el workflow de CI todavía no existe, dejar constancia explícita de esa limitación y tratar la integración en `main` como bloqueada.

--- a/docs/engineering-rules.md
+++ b/docs/engineering-rules.md
@@ -73,6 +73,7 @@ Este documento convierte el marco de `AGENTS.md` en comportamiento técnico conc
   - Cada tipo debe tener un propósito principal claro y verificable en su API pública.
   - Evitar funciones con intención opaca o ambigua; el nombre debe explicar la acción y el contexto de dominio (`classifyHourlyPrices`, `buildDailySummary`, `estimateApplianceCost`, etc.).
   - Si una función empieza a concentrar varias intenciones, dividirla en funciones más pequeñas con nombres explícitos.
+  - Evitar duplicidades o redundancias en código: no implementar dos veces la misma responsabilidad o comportamiento.
 - Control de acceso Swift (obligatorio):
   - Ser explícitos y escrupulosos con el nivel de acceso de cada tipo y miembro (`private`, `fileprivate`, `internal`, `public`, `open`).
   - Aplicar el principio de mínimo acceso necesario: usar el nivel más restrictivo que permita cumplir el caso.
@@ -94,6 +95,10 @@ Este documento convierte el marco de `AGENTS.md` en comportamiento técnico conc
 - Para reducers y efectos en `TCA`, seguir el enfoque oficial con `TestStore` descrito en la documentación de TCA:
   - https://pointfreeco.github.io/swift-composable-architecture/1.9.0/documentation/composablearchitecture/testing/
 - Si una suite existente usa `XCTest`, migrarla de forma incremental en el siguiente cambio que toque esa suite.
+- Evitar tests redundantes:
+  - cada test debe cubrir una intención diferente y aportar señal nueva;
+  - no duplicar en aceptación los mismos asserts detallados que ya están cubiertos en unit tests;
+  - mantener tests de aceptación en flujo integrado y tests unitarios en lógica puntual.
 
 ## Validación mínima obligatoria
 - Tras cambios de documentación:

--- a/docs/engineering-rules.md
+++ b/docs/engineering-rules.md
@@ -63,6 +63,13 @@ Este documento convierte el marco de `AGENTS.md` en comportamiento técnico conc
 - Evitar `UIKit` salvo integración necesaria y aislada.
 - No introducir abstracciones genéricas o reutilización prematura si el flujo base aún no existe.
 
+## Política de tests (obligatoria)
+- No usar `XCTest` en este proyecto salvo bloqueo técnico explícito y temporal.
+- Los tests deben implementarse con el framework `Testing` (`import Testing`, `@Test`, `#expect`, `#require`).
+- Para reducers y efectos en `TCA`, seguir el enfoque oficial con `TestStore` descrito en la documentación de TCA:
+  - https://pointfreeco.github.io/swift-composable-architecture/1.9.0/documentation/composablearchitecture/testing/
+- Si una suite existente usa `XCTest`, migrarla de forma incremental en el siguiente cambio que toque esa suite.
+
 ## Validación mínima obligatoria
 - Tras cambios de documentación:
   - revisar consistencia terminológica

--- a/docs/engineering-rules.md
+++ b/docs/engineering-rules.md
@@ -55,6 +55,24 @@ Este documento convierte el marco de `AGENTS.md` en comportamiento técnico conc
   - métodos
   - reducers, states y actions
 - Los textos visibles para usuario pueden estar en español; los identificadores de código no.
+- Orden y consistencia (cuando aplique):
+  - Ordenar alfabéticamente `import`s.
+  - Ordenar alfabéticamente las propiedades en `struct`s y `class`es si no existe un orden semántico más claro.
+  - Ordenar alfabéticamente los `case` en `enum`s.
+  - Excepción: mantener orden semántico cuando mejore la lectura del dominio (por ejemplo `Daypart`, o enums que representan un flujo temporal).
+- Regla de seguridad (anti-crash, obligatoria):
+  - Evitar crashes en runtime como requisito no negociable.
+  - Nunca indexar arrays/colecciones sin garantías de rango (out-of-bounds). Preferir iteración segura (`for element in ...`, `enumerated()`), `first/last`, o checks explícitos.
+  - Evitar `!` (force unwrap) y `as!` salvo que el valor esté previamente validado con `guard`/`if let` y la invariantes estén claras.
+  - Evitar `fatalError`, `preconditionFailure` y `assertionFailure` en código de producto salvo casos excepcionales y documentados.
+- Legibilidad y formato (obligatorio):
+  - Preferir firmas de funciones en una sola línea cuando sea razonable para lectura (evitar saltos justo después del nombre de la función).
+  - Mantener indentación consistente; al tocar un archivo en Xcode, re-indentar con `Control+i` (Editor > Structure > Re-Indent) antes de considerar el cambio listo.
+- Diseño y claridad de intención (obligatorio):
+  - No mezclar responsabilidades distintas dentro del mismo tipo (`class`, `struct`, `enum` o `actor`). Separar clasificación, agregación, cálculo, persistencia y orquestación cuando corresponda.
+  - Cada tipo debe tener un propósito principal claro y verificable en su API pública.
+  - Evitar funciones con intención opaca o ambigua; el nombre debe explicar la acción y el contexto de dominio (`classifyHourlyPrices`, `buildDailySummary`, `estimateApplianceCost`, etc.).
+  - Si una función empieza a concentrar varias intenciones, dividirla en funciones más pequeñas con nombres explícitos.
 - En features TCA:
   - introducir cambios primero en `State`, `Action`, `Reducer` y dependencias
   - después ajustar la vista y el wiring mínimo necesario

--- a/docs/engineering-rules.md
+++ b/docs/engineering-rules.md
@@ -8,6 +8,12 @@ Este documento convierte el marco de `AGENTS.md` en comportamiento técnico conc
 - Prefiere el cambio más pequeño que resuelva el problema de forma mantenible.
 - Si una decisión obliga a ampliar alcance, deja el motivo explícito en la respuesta final.
 
+## Preflight de sincronización (obligatorio)
+- Antes de cualquier edición, verificar rama activa y estado de sincronización con remoto.
+- Si la rama activa es `main`, ejecutar `git pull --ff-only origin main` antes de empezar.
+- Si la rama activa es una feature branch, ejecutar `git fetch origin` y comprobar que la base esperada existe y está alineada con `origin/main` antes de editar.
+- Si la sincronización falla (conflictos, red, permisos o historial no fast-forward), bloquear la implementación y no continuar sobre un estado desactualizado.
+
 ## Disciplina de alcance
 - No modificar más de una capa técnica a la vez salvo petición explícita o necesidad directa de integración.
 - Capas típicas en este proyecto:

--- a/docs/engineering-rules.md
+++ b/docs/engineering-rules.md
@@ -73,6 +73,13 @@ Este documento convierte el marco de `AGENTS.md` en comportamiento técnico conc
   - Cada tipo debe tener un propósito principal claro y verificable en su API pública.
   - Evitar funciones con intención opaca o ambigua; el nombre debe explicar la acción y el contexto de dominio (`classifyHourlyPrices`, `buildDailySummary`, `estimateApplianceCost`, etc.).
   - Si una función empieza a concentrar varias intenciones, dividirla en funciones más pequeñas con nombres explícitos.
+- Control de acceso Swift (obligatorio):
+  - Ser explícitos y escrupulosos con el nivel de acceso de cada tipo y miembro (`private`, `fileprivate`, `internal`, `public`, `open`).
+  - Aplicar el principio de mínimo acceso necesario: usar el nivel más restrictivo que permita cumplir el caso.
+  - Preferir `private` para detalles de implementación y helpers internos al tipo.
+  - Elevar a `internal` solo cuando exista uso real entre archivos/módulos dentro del target.
+  - Usar `public`/`open` únicamente con una necesidad clara de API externa y justificación explícita en el cambio.
+  - En revisiones, tratar como deuda cualquier símbolo más visible de lo necesario.
 - En features TCA:
   - introducir cambios primero en `State`, `Action`, `Reducer` y dependencias
   - después ajustar la vista y el wiring mínimo necesario

--- a/docs/implementation-roadmap.md
+++ b/docs/implementation-roadmap.md
@@ -77,6 +77,11 @@ Convert the documentation-first repository into a production-ready native iPhone
 - modelar tipos base de negocio
 - crear clientes inyectables para precios, persistencia, fecha y notificaciones
 - preparar pipeline de snapshot diario y caché
+- dejar evaluada la estrategia de modularización por capas (`Domain -> Clients -> Persistence`) como paso previo al siguiente hito
+
+#### Regla de transición `Hito 2 -> Hito 3`
+- Antes de iniciar `Hito 3`, revisar explícitamente si conviene extraer Swift Packages por capas.
+- No modularizar por feature UI en esta transición salvo necesidad técnica fuerte y justificada.
 
 ### Hito 3 — Shell de aplicación y estados raíz
 - consolidar `AppFeature`

--- a/docs/ios-architecture.md
+++ b/docs/ios-architecture.md
@@ -220,6 +220,15 @@ Responsabilidades:
 - Preparar los textos para localización, aunque la primera UI salga en español.
 - Usar `@Dependency` o `DependencyValues` para clientes de red, persistencia, calendario y notificaciones.
 
+## Estrategia de modularización (SPM)
+- La modularización con Swift Package Manager se planifica por capas estables, no por feature de UI en primera instancia.
+- Orden recomendado de extracción cuando toque modularizar:
+  - `Domain` (modelos y reglas puras)
+  - `Clients` (contratos y dependencias inyectables)
+  - `Persistence` (implementaciones de almacenamiento)
+- Evitar partir `Prices`, `Chart` o `Settings` en paquetes independientes hasta que el flujo base esté estabilizado y las fronteras de API sean claras.
+- Revisar esta decisión al cerrar la capa actual (`Hito 2`) y antes de iniciar la siguiente (`Hito 3`).
+
 ## Estrategia de persistencia
 - `sqlite-data` guardará:
   - precios horarios

--- a/docs/ios-architecture.md
+++ b/docs/ios-architecture.md
@@ -42,6 +42,7 @@ La app se construye como una base `iPhone-first` en `iOS 26+`, con `SwiftUI` y A
 - Los efectos asíncronos deben expresarse desde el reducer.
 - Las dependencias de red, persistencia, notificaciones y fecha deben inyectarse mediante el sistema de dependencias de TCA.
 - Los flujos importantes deben poder probarse con `TestStore`.
+- El marco de tests del proyecto es `Testing` (no `XCTest`), manteniendo el patrón de `TestStore` para reducers/efectos.
 - La composición debe hacerse por feature y no por capas globales monolíticas.
 
 ## Estructura de proyecto documentada
@@ -230,6 +231,11 @@ Responsabilidades:
   - preferencias ligeras de UI si aparecen
 
 ## Estrategia de pruebas
+- Framework base:
+  - usar `Testing` con `@Test`, `#expect` y `#require`
+  - no introducir suites nuevas con `XCTest`
+  - para testing de TCA, seguir la guía oficial:
+    - https://pointfreeco.github.io/swift-composable-architecture/1.9.0/documentation/composablearchitecture/testing/
 - Unit tests para:
   - clasificación relativa del día
   - resumen diario

--- a/docs/ios-architecture.md
+++ b/docs/ios-architecture.md
@@ -49,7 +49,7 @@ La app se construye como una base `iPhone-first` en `iOS 26+`, con `SwiftUI` y A
 ### `App`
 - Punto de entrada de la app, composición raíz, lifecycle y montaje del `Store` principal.
 - No contiene lógica de negocio específica de features.
-- Esta carpeta no existe todavía; se creará cuando arranque el bootstrap real del proyecto iOS.
+- Esta carpeta ya existe en `Sources/App` como parte del bootstrap técnico inicial y evolucionará con los hitos funcionales.
 
 ### `Features`
 - Contenedor de features verticales del producto.

--- a/project.yml
+++ b/project.yml
@@ -29,6 +29,8 @@ targets:
         INFOPLIST_FILE: Resources/Info.plist
         TARGETED_DEVICE_FAMILY: "1"
     dependencies:
+      - package: ComposableArchitecture
+        product: ComposableArchitecture
       - package: SQLiteData
         product: SQLiteData
 

--- a/project.yml
+++ b/project.yml
@@ -5,6 +5,7 @@ options:
     iOS: "26.0"
 settings:
   base:
+    SWIFT_STRICT_CONCURRENCY: complete
     SWIFT_VERSION: 6.0
     IPHONEOS_DEPLOYMENT_TARGET: 26.0
 packages:


### PR DESCRIPTION
## Summary
- add domain snapshot pipeline with explicit fresh/cached/failed outcomes
- add non-redundant acceptance coverage for issue #5 and keep unit tests focused
- document engineering rules for anti-crash, readability, access control, and anti-duplication
- document layer-based SPM modularization strategy for the Hito 2 -> Hito 3 transition

## Validation
- swiftlint lint --strict --no-cache
- xcodebuild -project PrecioLuzApp.xcodeproj -scheme PrecioLuzApp -destination 'platform=iOS Simulator,id=E7094472-7FA4-4BFD-9C11-970D8B3D1DA7' test

Closes #5
