### PR TITLE
Docs: remove duplicated operational rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,18 +14,6 @@
 - Idioma inicial de la app: español, con estructura preparada para localización futura.
 - Todo el código, incluyendo nombres de tipos, clases, propiedades, métodos, reducers, acciones y estados, debe escribirse en inglés.
 - Las notificaciones del producto son locales; no usar APS remotas en el alcance base.
-- Si existe proyecto Xcode, cualquier cambio que afecte UI, navegación o comportamiento visible debe validarse con `build` y simulador mediante `XcodeBuildMCP`.
-- Si todavía no existe proyecto Xcode o no es posible validar, deja constancia explícita de la limitación y no presentes la validación como realizada.
-- Cada feature debe integrarse en `main` a través de una `Pull Request`; no hacer merge directo a `main`.
-- El título y la descripción de cada `Pull Request` deben redactarse en inglés.
-- Si la `Pull Request` contiene código, el CI mínimo en `GitHub Actions` debe incluir al menos `build` y ejecución de tests, y ambos deben estar en verde antes del merge.
-- Si la `Pull Request` es solo documental, no requiere `build` Xcode, pero sí debe pasar cualquier check documental configurado.
-- Si todavía no existe workflow de CI en `GitHub Actions`, la feature no debe considerarse lista para merge; esa ausencia debe quedar señalada explícitamente como bloqueo de integración.
-- Cada tarea debe crearse como `GitHub Issue` descriptiva antes de iniciar implementación.
-- El título y la descripción de cada `GitHub Issue` deben redactarse en inglés.
-- Cada `GitHub Issue` debe documentar dependencias explícitas (`Depends on` y `Blocks`) cuando aplique.
-- Cada tarea debe implementarse en una feature branch asociada a su issue.
-- Cada `Pull Request` debe enlazar su `Issue` de origen y respetar sus dependencias declaradas.
 
 ## Límites de alcance
 - No usar notificaciones push remotas.
@@ -35,7 +23,7 @@
 - No inventes arquitectura ni convenciones si todavía no están definidas en el repo.
 - Usa los documentos de `docs/` como fuente de verdad para el detalle funcional, técnico y visual.
 - `AGENTS.md` define marco, límites y prioridades.
-- `docs/engineering-rules.md` concreta cómo ejecutar tareas técnicas dentro de ese marco.
+- `docs/engineering-rules.md` es la fuente única de reglas operativas de ejecución: preflight, disciplina de alcance, validación, integración por PR, CI y trazabilidad con issues/dependencias.
 - `docs/codex-project-prompt.md` es un apoyo de ejecución concreta y no puede reemplazar ni contradecir este archivo.
 - Si dos documentos entran en conflicto, prioriza este archivo y después `docs/product-spec.md`.
 

--- a/docs/codex-project-prompt.md
+++ b/docs/codex-project-prompt.md
@@ -1,58 +1,43 @@
 # Codex Project Prompt
 
-Usa este documento como prompt operativo auxiliar del proyecto. Complementa `AGENTS.md`, no lo sustituye y no puede contradecirlo.
+Usa este documento como plantilla operativa auxiliar para una tarea concreta. Complementa `AGENTS.md`, no lo sustituye y no puede contradecirlo.
 
 ## Uso correcto
 - Úsalo para encuadrar una tarea concreta, no para redefinir normas del proyecto.
-- Antes de ejecutar, consulta siempre:
-  - `AGENTS.md`
-  - `docs/engineering-rules.md`
-  - `docs/product-spec.md`
-  - `docs/ios-architecture.md`
-  - `docs/ui-direction.md` cuando la tarea afecte UI
+- Trata `docs/engineering-rules.md` como fuente única para ejecución técnica (preflight, alcance, validación, PR/CI e issues/dependencias).
 - Si este documento entra en conflicto con `AGENTS.md`, manda `AGENTS.md`.
 
-## Plantilla de ejecución
+## Plantilla mínima de ejecución
 
 ```md
 <task_context>
 Proyecto: PrecioLuzApp
 Tarea: [describir aquí el cambio pedido]
 Área afectada: [feature, pantalla o capa técnica]
-Documentos a revisar:
-- AGENTS.md
-- docs/engineering-rules.md
-- docs/product-spec.md
-- docs/ios-architecture.md
-- docs/ui-direction.md (si aplica)
+Tipo de cambio: [documentación | código sin impacto visible | UI/comportamiento visible]
 </task_context>
 
-<preflight_sync>
-- Si estás en `main`, ejecuta `git pull --ff-only origin main`.
-- Si estás en feature branch, ejecuta `git fetch origin` y confirma alineación/base contra `origin/main`.
-- Si falla la sincronización, no implementes sobre estado desactualizado; deja el bloqueo explícito.
-</preflight_sync>
+<required_docs>
+- AGENTS.md
+- docs/engineering-rules.md
+- docs/product-spec.md (si aplica)
+- docs/ios-architecture.md (si aplica)
+- docs/ui-direction.md (si aplica)
+</required_docs>
 
-<execution_focus>
-- Limita el cambio al alcance pedido.
-- No toques archivos no relacionados.
-- Si necesitas ampliar alcance, explica por qué.
-- Mantén alineación con TCA, stack aprobado y naming en inglés para identificadores de código.
-</execution_focus>
-
-<validation>
-- Ejecuta la validación mínima realmente disponible para la tarea.
-- Si no puedes validar, explica la limitación de forma explícita.
-- No presentes validaciones no ejecutadas como realizadas.
-</validation>
+<execution_contract>
+- Aplicar el cambio más pequeño y reversible posible.
+- Limitar el cambio al alcance pedido.
+- Declarar explícitamente cualquier limitación de validación.
+</execution_contract>
 
 <response_expectations>
-- Resume el cambio real.
-- Lista supuestos o límites si existen.
-- Indica qué validación se ejecutó de verdad.
+- Resumen del cambio real aplicado.
+- Validación ejecutada de verdad (según `docs/engineering-rules.md`).
+- Supuestos, bloqueos o límites pendientes.
 </response_expectations>
 ```
 
 ## Notas
 - Mantén este documento ligero.
-- No dupliques aquí reglas de alcance, arquitectura o validación que ya vivan mejor en `AGENTS.md` o `docs/engineering-rules.md`.
+- No dupliques aquí reglas que ya estén definidas en `AGENTS.md` o `docs/engineering-rules.md`.


### PR DESCRIPTION
## Summary
- remove duplicated operational integration and validation rules from AGENTS.md
- keep docs/engineering-rules.md as the single source of operational execution rules
- simplify docs/codex-project-prompt.md to a lightweight task template that references canonical docs

## Why
There was high redundancy across AGENTS.md, docs/engineering-rules.md and docs/codex-project-prompt.md, which increased maintenance cost and risk of drift.

## Scope
Documentation-only changes. No code/runtime behavior changes.