### PR TITLE
Improve README marketing positioning and App Store strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,60 +1,127 @@
 # PrecioLuzApp ⚡📱
 
-> A native iPhone app to understand electricity prices at a glance, explore daily trends, and get smart local alerts before expensive hours hit.
+> La app nativa de iPhone para saber **cuándo conviene consumir electricidad en España** sin interpretar tablas complejas.
 
-## ✨ What is this project?
+`PrecioLuzApp` ayuda a usuarios domésticos con tarifa indexada o PVPC a entender el precio horario de la luz, localizar las mejores horas del día y recibir avisos locales antes de los momentos más caros o más interesantes.
 
-`PrecioLuzApp` is an iPhone-first app focused on Spanish hourly electricity pricing.
+La propuesta no es solo mostrar precios: es convertir datos horarios en decisiones simples.
 
-The goal is simple:
+## Propuesta de valor
 
-- 🟢 show when electricity is cheap
-- 🟠 highlight mid-range hours
-- 🔴 warn when prices are expensive
-- 🧮 help users estimate appliance cost from a selected hour
-- 🔔 schedule local notifications for daily minimums, maximums, and custom thresholds
+- Ver el precio actual de la luz en segundos.
+- Detectar rápidamente las horas baratas, medias y caras del día.
+- Comparar visualmente la evolución diaria por tramos.
+- Estimar el coste de usar electrodomésticos en una hora concreta.
+- Recibir avisos locales sobre mínimos, máximos y umbrales personalizados.
+- Funcionar sin cuenta, sin backend propio y con una experiencia iPhone-first.
 
-This project is also intentionally being used as a learning playground for:
+## Para quién es
 
-- 🧩 The Composable Architecture (`TCA`)
-- 🍎 modern native iOS development
-- 🪟 SwiftUI-first UI patterns
-- 🧪 testable feature design
+`PrecioLuzApp` está pensada para personas en España que consultan el precio de la electricidad durante el día y quieren decidir mejor cuándo usar lavadora, lavavajillas, termo, climatización u otros consumos domésticos.
 
-## 📲 Planned app experience
+El caso de uso principal es claro:
 
-The app is designed around **three tabs**:
+> “Quiero saber de un vistazo si ahora es buen momento para consumir electricidad o si me conviene esperar.”
 
-### 1. Prices ⏰
-- Daily summary cards for current, average, minimum, and maximum price
-- A 24-hour price list
-- Color-coded hourly slots for cheap, mid, and expensive periods
-- A modal cost calculator when the user taps a time slot
+## Experiencia principal
 
-### 2. Chart 📈
-- A daily chart split into clear day sections
-- Fast visual comparison between time ranges
-- Hourly inspection for a selected time segment
+La app se organiza alrededor de tres tabs:
 
-### 3. Settings ⚙️
-- Local notification toggles
-- Daily minimum alert
-- Daily maximum alert
-- Custom price-threshold alert
+### 1. Precios ⏰
 
-## 🧠 Product direction
+Lectura rápida del día:
 
-The current product definition assumes:
+- tarjetas de resumen para precio actual, media, mínimo y máximo;
+- listado horario completo;
+- clasificación visual por hora barata, media o cara;
+- resaltado de la hora actual;
+- acceso al cálculo estimado de coste desde una franja horaria.
 
-- 🇪🇸 Spanish market pricing with `ESIOS/PVPC` as the initial source of truth
-- 📆 up to `30 days` of local history
-- 🔔 local notifications only
-- 📱 iPhone-only scope for the base version
-- 🌙 a dark, modern, native iOS visual direction
+### 2. Gráfica 📈
 
-## 🏗️ Tech direction
+Exploración visual del precio:
 
-The project documentation currently defines this stack:
+- gráfica diaria con `Charts` nativo;
+- segmentación por madrugada, mañana, tarde y noche;
+- inspección puntual de una hora concreta;
+- comparación rápida entre tramos del día.
+
+### 3. Ajustes ⚙️
+
+Control de avisos locales:
+
+- activar o desactivar notificaciones;
+- aviso del mínimo diario;
+- aviso del máximo diario;
+- aviso por umbral personalizado en `€/kWh`.
+
+## Diferenciación de producto
+
+Muchas herramientas muestran el precio de la luz. `PrecioLuzApp` busca diferenciarse por:
+
+- **claridad inmediata**: semáforo horario y resumen diario sin ruido;
+- **decisión accionable**: saber cuándo consumir, no solo cuánto cuesta;
+- **experiencia nativa iOS**: SwiftUI, Charts, animaciones funcionales y diseño oscuro moderno;
+- **privacidad y simplicidad**: sin login, sin cuenta y sin servidor propio en el alcance base;
+- **avisos locales**: utilidad diaria sin depender de push remotas.
+
+## Alcance actual
+
+La implementación actual está orientada a una base comercializable de MVP avanzado:
+
+- ✅ proyecto iPhone generado con `XcodeGen`;
+- ✅ arquitectura basada en `SwiftUI`, `TCA` y `Swift Concurrency`;
+- ✅ tabs `Precios`, `Gráfica` y `Ajustes`;
+- ✅ modelos de dominio y clientes inyectables;
+- ✅ integración de datos `REE/ESIOS` mediante clave local;
+- ✅ persistencia local e histórico reciente;
+- ✅ cálculo estimado de coste por electrodoméstico;
+- ✅ notificaciones locales para mínimo, máximo y umbral;
+- ✅ estados de resiliencia: loading, empty, error, cached y retry;
+- ✅ cobertura de tests, snapshots y UI smoke;
+- ✅ CI de `build` + `test`.
+
+## Datos y precisión
+
+La app usa `REE/ESIOS` como fuente inicial para precios horarios del mercado español.
+
+El cálculo de coste de electrodomésticos es una estimación basada en potencia y duración. Esto permite validar el flujo de producto en el MVP, pero no debe presentarse como consumo real medido.
+
+Evoluciones naturales del producto:
+
+- perfiles personalizados de electrodoméstico;
+- consumo por ciclo introducido desde etiqueta energética;
+- cálculo multi-hora cuando un ciclo cruza varias franjas;
+- integración futura con medición real mediante enchufes inteligentes, Home Assistant o estándares compatibles.
+
+## Posicionamiento App Store
+
+Posicionamiento recomendado:
+
+> Ahorra atención, no solo céntimos: consulta la luz, encuentra las mejores horas y recibe avisos útiles desde tu iPhone.
+
+Ideas de subtítulo:
+
+- `Precio de la luz y avisos útiles`
+- `Encuentra las horas baratas del día`
+- `Decide cuándo consumir electricidad`
+
+Promesa principal:
+
+> Entiende el precio horario de la luz y decide mejor cuándo usar tus electrodomésticos.
+
+Ver estrategia ampliada en [`docs/app-store-positioning.md`](docs/app-store-positioning.md).
+
+## Dirección de monetización
+
+La app encaja mejor con un modelo `freemium`:
+
+- versión gratuita para consulta diaria, resumen, gráfica básica y avisos esenciales;
+- versión Pro para personalización avanzada, alertas inteligentes, widgets, perfiles de electrodoméstico, histórico ampliado y mejores estimaciones de coste.
+
+No se recomienda monetizar el simple acceso al precio horario. El valor de pago debería estar en la capa de decisión: recomendaciones, personalización, automatización y análisis.
+
+## Stack técnico
 
 - `SwiftUI`
 - `Swift Concurrency`
@@ -63,47 +130,35 @@ The project documentation currently defines this stack:
 - `URLSession`
 - `The Composable Architecture`
 - `sqlite-data`
+- `SnapshotTesting`
+- `XcodeGen`
 
-## 🔐 Local REE/ESIOS API key
+## Clave local REE/ESIOS
 
-Real REE/ESIOS data is loaded from the local `REE_API_KEY` secret. The key must not be committed.
+Los datos reales de `REE/ESIOS` se cargan desde el secreto local `REE_API_KEY`. La clave no debe commitearse.
 
-For local development, create a repo-root `.env` file and add the `REE_API_KEY` entry with your local token.
+Para desarrollo local, crea un archivo `.env` en la raíz del repo:
 
-The shared Xcode scheme only stores `PRECIOLUZ_ENV_FILE=$(SRCROOT)/.env`, which is a non-secret path. Unit tests read that local file when the variable is not already present in the process environment.
+```env
+REE_API_KEY=tu_token_local
+```
 
-For simulator Debug app runs, XcodeGen config copies the local `.env` into the built app bundle as `PrecioLuzLocal.env`. That generated bundle resource is local build output only; it is not tracked and is removed for non-Debug configurations.
+El scheme compartido solo guarda `PRECIOLUZ_ENV_FILE=$(SRCROOT)/.env`, que es una ruta local no secreta. En ejecuciones Debug de simulador, `XcodeGen` copia ese `.env` al bundle como `PrecioLuzLocal.env`. Ese recurso generado es salida local de build, no se versiona y se elimina en configuraciones no Debug.
 
-## 🚧 Current status
+## Documentación
 
-Roadmap implementation is currently delivered through `Milestone 8` at local-repo level:
+- [`AGENTS.md`](AGENTS.md) — gobierno del proyecto, límites y prioridades.
+- [`docs/product-spec.md`](docs/product-spec.md) — contrato funcional del producto.
+- [`docs/app-store-positioning.md`](docs/app-store-positioning.md) — posicionamiento, ASO, capturas y monetización.
+- [`docs/ios-architecture.md`](docs/ios-architecture.md) — estructura técnica y responsabilidades.
+- [`docs/engineering-rules.md`](docs/engineering-rules.md) — reglas de ejecución, validación, CI y PRs.
+- [`docs/ui-direction.md`](docs/ui-direction.md) — dirección visual y UX.
+- [`docs/implementation-roadmap.md`](docs/implementation-roadmap.md) — roadmap de implementación.
+- [`docs/validation-evidence.md`](docs/validation-evidence.md) — evidencias de validación.
+- [`docs/codex-project-prompt.md`](docs/codex-project-prompt.md) — prompt auxiliar de ejecución.
 
-- ✅ iPhone Xcode project generated via `project.yml` (`XcodeGen`)
-- ✅ `TCA` + `sqlite-data` dependencies integrated
-- ✅ base `TabView` shell with `Precios`, `Gráfica`, `Ajustes`
-- ✅ SF Symbols configured for tabs (`eurosign.circle`, `chart.xyaxis.line`, `gearshape`)
-- ✅ localized tab titles via `Localizable.strings` (`es` and `en`)
-- ✅ domain models + injectable clients (`pricing`, `persistence`, `date`, `notifications`)
-- ✅ `Prices`, `Chart`, `Settings`, and `CostCalculation` features
-- ✅ resilience + QA hardening baseline (`offline/cached/error/retry`) with acceptance/snapshot/ui smoke coverage
-- ✅ baseline shell tests + TCA smoke tests
-- ✅ GitHub Actions CI workflow for `build` + `test`
-- ✅ validation evidence documented up to `Issue #11` final checkpoint in `docs/validation-evidence.md`
+## Principio de producto
 
-Pending roadmap work is now mainly integration traceability (`Done-Integrated`) and follow-up increments/issues after milestone closure.
+`PrecioLuzApp` no debe sentirse como una tabla de precios. Debe sentirse como una decisión rápida:
 
-## 📚 Documentation map
-
-If you want the full project definition, start here:
-
-- `AGENTS.md` — project governance, boundaries, and priorities
-- `docs/product-spec.md` — functional product contract
-- `docs/ios-architecture.md` — technical structure and planned folder responsibilities
-- `docs/engineering-rules.md` — execution rules for implementation work
-- `docs/ui-direction.md` — visual and UX direction
-- `docs/implementation-roadmap.md` — step-by-step delivery roadmap
-- `docs/codex-project-prompt.md` — lightweight execution prompt template
-
----
-
-Built with ⚡ energy data, 📱 native iOS ideas, and 🧠 a strong bias toward clarity.
+> “Ahora sí”, “mejor espera” o “ponlo en esta franja”.

--- a/README.md
+++ b/README.md
@@ -1,127 +1,128 @@
 # PrecioLuzApp ⚡📱
 
-> La app nativa de iPhone para saber **cuándo conviene consumir electricidad en España** sin interpretar tablas complejas.
+> A native iPhone app that helps people in Spain decide **when it is worth using electricity** without reading complex price tables.
 
-`PrecioLuzApp` ayuda a usuarios domésticos con tarifa indexada o PVPC a entender el precio horario de la luz, localizar las mejores horas del día y recibir avisos locales antes de los momentos más caros o más interesantes.
+`PrecioLuzApp` helps domestic users with PVPC or indexed electricity tariffs understand hourly electricity prices, spot the best hours of the day, and receive useful local alerts before expensive or convenient time slots arrive.
 
-La propuesta no es solo mostrar precios: es convertir datos horarios en decisiones simples.
+The product goal is not only to display prices. The goal is to turn hourly market data into simple everyday decisions.
 
-## Propuesta de valor
+## Value proposition
 
-- Ver el precio actual de la luz en segundos.
-- Detectar rápidamente las horas baratas, medias y caras del día.
-- Comparar visualmente la evolución diaria por tramos.
-- Estimar el coste de usar electrodomésticos en una hora concreta.
-- Recibir avisos locales sobre mínimos, máximos y umbrales personalizados.
-- Funcionar sin cuenta, sin backend propio y con una experiencia iPhone-first.
+- See the current electricity price in seconds.
+- Quickly identify cheap, mid-range, and expensive hours.
+- Compare the daily price curve by time segment.
+- Estimate appliance usage cost from a selected hour.
+- Receive local alerts for daily minimums, maximums, and custom thresholds.
+- Stay iPhone-first, privacy-conscious, and simple: no account and no backend in the base scope.
 
-## Para quién es
+## Target user
 
-`PrecioLuzApp` está pensada para personas en España que consultan el precio de la electricidad durante el día y quieren decidir mejor cuándo usar lavadora, lavavajillas, termo, climatización u otros consumos domésticos.
+`PrecioLuzApp` is designed for people in Spain who check electricity prices during the day and want to make better decisions about when to use appliances such as washing machines, dishwashers, water heaters, cooking devices, or climate control.
 
-El caso de uso principal es claro:
+The main user job is simple:
 
-> “Quiero saber de un vistazo si ahora es buen momento para consumir electricidad o si me conviene esperar.”
+> “I want to know at a glance whether now is a good time to use electricity or whether I should wait.”
 
-## Experiencia principal
+## Core app experience
 
-La app se organiza alrededor de tres tabs:
+The app is organized around three tabs:
 
-### 1. Precios ⏰
+### 1. Prices ⏰
 
-Lectura rápida del día:
+Fast daily reading:
 
-- tarjetas de resumen para precio actual, media, mínimo y máximo;
-- listado horario completo;
-- clasificación visual por hora barata, media o cara;
-- resaltado de la hora actual;
-- acceso al cálculo estimado de coste desde una franja horaria.
+- summary cards for current, average, minimum, and maximum price;
+- complete hourly price list;
+- visual classification for cheap, mid-range, and expensive slots;
+- current-hour highlighting;
+- access to an estimated appliance cost calculation from any selected hourly slot.
 
-### 2. Gráfica 📈
+### 2. Chart 📈
 
-Exploración visual del precio:
+Visual price exploration:
 
-- gráfica diaria con `Charts` nativo;
-- segmentación por madrugada, mañana, tarde y noche;
-- inspección puntual de una hora concreta;
-- comparación rápida entre tramos del día.
+- native `Charts` daily graph;
+- fixed daypart segmentation: overnight, morning, afternoon, and night;
+- point inspection for a selected hour;
+- quick comparison between different parts of the day.
 
-### 3. Ajustes ⚙️
+### 3. Settings ⚙️
 
-Control de avisos locales:
+Local alert control:
 
-- activar o desactivar notificaciones;
-- aviso del mínimo diario;
-- aviso del máximo diario;
-- aviso por umbral personalizado en `€/kWh`.
+- notification enablement;
+- daily minimum alert;
+- daily maximum alert;
+- custom threshold alert in `€/kWh`.
 
-## Diferenciación de producto
+## Product differentiation
 
-Muchas herramientas muestran el precio de la luz. `PrecioLuzApp` busca diferenciarse por:
+Many tools show electricity prices. `PrecioLuzApp` aims to differentiate through:
 
-- **claridad inmediata**: semáforo horario y resumen diario sin ruido;
-- **decisión accionable**: saber cuándo consumir, no solo cuánto cuesta;
-- **experiencia nativa iOS**: SwiftUI, Charts, animaciones funcionales y diseño oscuro moderno;
-- **privacidad y simplicidad**: sin login, sin cuenta y sin servidor propio en el alcance base;
-- **avisos locales**: utilidad diaria sin depender de push remotas.
+- **immediate clarity**: hourly traffic-light semantics and daily summary without noise;
+- **actionable decisions**: knowing when to consume, not only how much electricity costs;
+- **native iOS quality**: SwiftUI, Charts, functional motion, and a modern dark visual direction;
+- **privacy and simplicity**: no login, no account, and no own backend in the base scope;
+- **local alerts**: daily utility without relying on remote push notifications.
 
-## Alcance actual
+## Current scope
 
-La implementación actual está orientada a una base comercializable de MVP avanzado:
+The current implementation is positioned as an advanced MVP foundation:
 
-- ✅ proyecto iPhone generado con `XcodeGen`;
-- ✅ arquitectura basada en `SwiftUI`, `TCA` y `Swift Concurrency`;
-- ✅ tabs `Precios`, `Gráfica` y `Ajustes`;
-- ✅ modelos de dominio y clientes inyectables;
-- ✅ integración de datos `REE/ESIOS` mediante clave local;
-- ✅ persistencia local e histórico reciente;
-- ✅ cálculo estimado de coste por electrodoméstico;
-- ✅ notificaciones locales para mínimo, máximo y umbral;
-- ✅ estados de resiliencia: loading, empty, error, cached y retry;
-- ✅ cobertura de tests, snapshots y UI smoke;
-- ✅ CI de `build` + `test`.
+- ✅ iPhone project generated with `XcodeGen`;
+- ✅ architecture based on `SwiftUI`, `TCA`, and `Swift Concurrency`;
+- ✅ `Prices`, `Chart`, and `Settings` tabs;
+- ✅ domain models and injectable clients;
+- ✅ `REE/ESIOS` data integration through a local API key;
+- ✅ local persistence and recent history;
+- ✅ estimated appliance cost calculation;
+- ✅ local notifications for daily minimum, daily maximum, and threshold alerts;
+- ✅ resilience states: loading, empty, error, cached, and retry;
+- ✅ test coverage, snapshots, and UI smoke tests;
+- ✅ CI workflow for `build` and `test`.
 
-## Datos y precisión
+## Data and precision
 
-La app usa `REE/ESIOS` como fuente inicial para precios horarios del mercado español.
+The app uses `REE/ESIOS` as the initial source of truth for Spanish hourly electricity prices.
 
-El cálculo de coste de electrodomésticos es una estimación basada en potencia y duración. Esto permite validar el flujo de producto en el MVP, pero no debe presentarse como consumo real medido.
+Appliance cost calculation is currently an estimate based on power and duration. This is valid for MVP validation, but it should not be presented as real measured consumption.
 
-Evoluciones naturales del producto:
+Natural product evolutions include:
 
-- perfiles personalizados de electrodoméstico;
-- consumo por ciclo introducido desde etiqueta energética;
-- cálculo multi-hora cuando un ciclo cruza varias franjas;
-- integración futura con medición real mediante enchufes inteligentes, Home Assistant o estándares compatibles.
+- custom appliance profiles;
+- energy-per-cycle values entered from energy labels;
+- multi-hour calculation when an appliance cycle crosses hourly slots;
+- future integration with real measurements through smart plugs, Home Assistant, or compatible standards.
 
-## Posicionamiento App Store
+## App Store positioning
 
-Posicionamiento recomendado:
+Recommended positioning:
 
-> Ahorra atención, no solo céntimos: consulta la luz, encuentra las mejores horas y recibe avisos útiles desde tu iPhone.
+> Save attention, not only cents: check electricity prices, find the best hours, and get useful alerts from your iPhone.
 
-Ideas de subtítulo:
+Subtitle candidates:
 
-- `Precio de la luz y avisos útiles`
-- `Encuentra las horas baratas del día`
-- `Decide cuándo consumir electricidad`
+- `Electricity prices and alerts`
+- `Find today’s cheapest hours`
+- `Decide when to use electricity`
+- `PVPC prices, charts, and alerts`
 
-Promesa principal:
+Main promise:
 
-> Entiende el precio horario de la luz y decide mejor cuándo usar tus electrodomésticos.
+> Understand hourly electricity prices and make better decisions about when to use your appliances.
 
-Ver estrategia ampliada en [`docs/app-store-positioning.md`](docs/app-store-positioning.md).
+See the extended strategy in [`docs/app-store-positioning.md`](docs/app-store-positioning.md).
 
-## Dirección de monetización
+## Monetization direction
 
-La app encaja mejor con un modelo `freemium`:
+The app is best suited to a `freemium` model:
 
-- versión gratuita para consulta diaria, resumen, gráfica básica y avisos esenciales;
-- versión Pro para personalización avanzada, alertas inteligentes, widgets, perfiles de electrodoméstico, histórico ampliado y mejores estimaciones de coste.
+- a free version for daily price lookup, summaries, basic charts, and essential alerts;
+- a Pro version for advanced personalization, smart alerts, widgets, appliance profiles, extended history, and better cost estimates.
 
-No se recomienda monetizar el simple acceso al precio horario. El valor de pago debería estar en la capa de decisión: recomendaciones, personalización, automatización y análisis.
+The app should not monetize simple access to public hourly price data. Paid value should live in the decision layer: recommendations, personalization, automation, widgets, and analysis.
 
-## Stack técnico
+## Technical stack
 
 - `SwiftUI`
 - `Swift Concurrency`
@@ -133,32 +134,32 @@ No se recomienda monetizar el simple acceso al precio horario. El valor de pago 
 - `SnapshotTesting`
 - `XcodeGen`
 
-## Clave local REE/ESIOS
+## Local REE/ESIOS API key
 
-Los datos reales de `REE/ESIOS` se cargan desde el secreto local `REE_API_KEY`. La clave no debe commitearse.
+Real `REE/ESIOS` data is loaded from the local `REE_API_KEY` secret. The key must not be committed.
 
-Para desarrollo local, crea un archivo `.env` en la raíz del repo:
+For local development, create a repo-root `.env` file:
 
 ```env
-REE_API_KEY=tu_token_local
+REE_API_KEY=your_local_token
 ```
 
-El scheme compartido solo guarda `PRECIOLUZ_ENV_FILE=$(SRCROOT)/.env`, que es una ruta local no secreta. En ejecuciones Debug de simulador, `XcodeGen` copia ese `.env` al bundle como `PrecioLuzLocal.env`. Ese recurso generado es salida local de build, no se versiona y se elimina en configuraciones no Debug.
+The shared Xcode scheme only stores `PRECIOLUZ_ENV_FILE=$(SRCROOT)/.env`, which is a non-secret local path. For simulator Debug runs, `XcodeGen` copies the local `.env` into the built app bundle as `PrecioLuzLocal.env`. That generated bundle resource is local build output only; it is not tracked and is removed for non-Debug configurations.
 
-## Documentación
+## Documentation
 
-- [`AGENTS.md`](AGENTS.md) — gobierno del proyecto, límites y prioridades.
-- [`docs/product-spec.md`](docs/product-spec.md) — contrato funcional del producto.
-- [`docs/app-store-positioning.md`](docs/app-store-positioning.md) — posicionamiento, ASO, capturas y monetización.
-- [`docs/ios-architecture.md`](docs/ios-architecture.md) — estructura técnica y responsabilidades.
-- [`docs/engineering-rules.md`](docs/engineering-rules.md) — reglas de ejecución, validación, CI y PRs.
-- [`docs/ui-direction.md`](docs/ui-direction.md) — dirección visual y UX.
-- [`docs/implementation-roadmap.md`](docs/implementation-roadmap.md) — roadmap de implementación.
-- [`docs/validation-evidence.md`](docs/validation-evidence.md) — evidencias de validación.
-- [`docs/codex-project-prompt.md`](docs/codex-project-prompt.md) — prompt auxiliar de ejecución.
+- [`AGENTS.md`](AGENTS.md) — project governance, boundaries, and priorities.
+- [`docs/product-spec.md`](docs/product-spec.md) — functional product contract.
+- [`docs/app-store-positioning.md`](docs/app-store-positioning.md) — positioning, ASO, screenshots, and monetization direction.
+- [`docs/ios-architecture.md`](docs/ios-architecture.md) — technical structure and planned responsibilities.
+- [`docs/engineering-rules.md`](docs/engineering-rules.md) — execution, validation, CI, and PR rules.
+- [`docs/ui-direction.md`](docs/ui-direction.md) — visual and UX direction.
+- [`docs/implementation-roadmap.md`](docs/implementation-roadmap.md) — implementation roadmap.
+- [`docs/validation-evidence.md`](docs/validation-evidence.md) — validation evidence.
+- [`docs/codex-project-prompt.md`](docs/codex-project-prompt.md) — lightweight execution prompt template.
 
-## Principio de producto
+## Product principle
 
-`PrecioLuzApp` no debe sentirse como una tabla de precios. Debe sentirse como una decisión rápida:
+`PrecioLuzApp` should not feel like a price table. It should feel like a fast decision:
 
-> “Ahora sí”, “mejor espera” o “ponlo en esta franja”.
+> “Use electricity now”, “wait”, or “choose this cheaper slot”.

--- a/docs/app-store-positioning.md
+++ b/docs/app-store-positioning.md
@@ -1,0 +1,291 @@
+# App Store Positioning
+
+## Objetivo
+
+Definir una base de posicionamiento comercial para `PrecioLuzApp` antes de preparar ficha de App Store, screenshots, paywall o futuras decisiones de monetización.
+
+La app debe posicionarse como una herramienta de decisión doméstica, no como una simple tabla de precios eléctricos.
+
+## Posicionamiento principal
+
+`PrecioLuzApp` ayuda a personas en España a saber cuándo conviene consumir electricidad durante el día, usando precios horarios, lectura visual rápida y avisos locales.
+
+### Frase de posicionamiento
+
+> Consulta el precio horario de la luz, encuentra las mejores horas del día y recibe avisos útiles antes de consumir.
+
+### Promesa de producto
+
+> Entender la luz en segundos y decidir mejor cuándo usar tus electrodomésticos.
+
+### Mensaje clave
+
+No se trata solo de ver precios. Se trata de transformar datos horarios en decisiones sencillas:
+
+- ahora conviene;
+- mejor espera;
+- esta es la hora barata;
+- evita esta franja;
+- activa un aviso y olvídate.
+
+## Público objetivo
+
+### Usuario principal
+
+Personas en España con tarifa indexada, PVPC o sensibilidad al precio horario de electricidad.
+
+Necesidades:
+
+- consultar el precio actual rápido;
+- localizar horas baratas sin interpretar tablas densas;
+- recibir avisos antes de las mejores o peores horas;
+- estimar cuánto puede costar usar un electrodoméstico;
+- evitar configurar sistemas complejos.
+
+### Casos de uso principales
+
+| Caso | Necesidad | Respuesta de la app |
+|---|---|---|
+| Poner lavadora | Saber si conviene ahora o después | Precio actual + horas baratas |
+| Cocinar | Evitar una franja cara | Lista horaria + máximo diario |
+| Planificar consumo | Buscar tramo barato disponible | Gráfica por tramos |
+| Control diario | No mirar la app cada hora | Notificaciones locales |
+| Estimar coste | Entender impacto aproximado | Calculadora por electrodoméstico |
+
+## Propuesta de valor
+
+### Valor funcional
+
+- Precio horario de electricidad en España.
+- Resumen del día: actual, media, mínimo y máximo.
+- Semáforo horario para distinguir barato, medio y caro.
+- Gráfica diaria por tramos.
+- Estimación de coste por electrodoméstico.
+- Avisos locales configurables.
+
+### Valor emocional
+
+- Menos incertidumbre.
+- Más control sobre el consumo doméstico.
+- Menos necesidad de revisar webs o tablas.
+- Sensación de tomar mejores decisiones con poco esfuerzo.
+
+### Valor diferencial
+
+- Experiencia nativa iPhone.
+- Sin cuenta en el alcance base.
+- Sin backend propio en el alcance base.
+- Diseño oscuro y lectura rápida.
+- Avisos locales centrados en utilidad, no en engagement artificial.
+
+## Mensajes para App Store
+
+### Nombre
+
+Nombre actual:
+
+```text
+PrecioLuzApp
+```
+
+Es claro para desarrollo, pero podría evaluarse un nombre comercial más natural antes de publicar.
+
+Opciones:
+
+- `Precio Luz`
+- `Precio Luz España`
+- `Luz Horaria`
+- `Luz Hoy`
+- `Ahorra Luz`
+
+Criterio: priorizar claridad ASO sobre originalidad.
+
+### Subtítulos posibles
+
+- `Precio de la luz y avisos útiles`
+- `Encuentra las horas baratas del día`
+- `Decide cuándo consumir electricidad`
+- `PVPC, horarios y alertas locales`
+- `Ahorra luz con mejores horarios`
+
+### Texto promocional
+
+```text
+Consulta el precio horario de la luz en España, localiza las horas baratas y recibe avisos para decidir mejor cuándo consumir electricidad.
+```
+
+### Descripción corta
+
+```text
+PrecioLuzApp te ayuda a entender el precio horario de la electricidad en España. Consulta el precio actual, encuentra las horas baratas del día, revisa la evolución por tramos y activa avisos locales para mínimos, máximos o umbrales personalizados.
+```
+
+### Descripción ampliada
+
+```text
+PrecioLuzApp convierte el precio horario de la luz en una decisión sencilla.
+
+Consulta de un vistazo cuánto cuesta la electricidad ahora, cuál es el mínimo y máximo del día, y qué horas son más convenientes para usar tus electrodomésticos.
+
+La app muestra una lista horaria clara, una gráfica diaria por tramos y una calculadora de coste estimado para entender mejor el impacto de consumir en una hora concreta.
+
+También puedes activar avisos locales para recibir una notificación antes de las mejores o peores franjas, sin crear cuenta y sin depender de notificaciones remotas.
+```
+
+## Keywords ASO
+
+> Pendiente de validación real en App Store Connect y análisis competitivo.
+
+Ideas iniciales:
+
+```text
+precio luz, luz hoy, PVPC, electricidad, tarifa luz, luz barata, precio electricidad, ahorro luz, hora barata, factura luz
+```
+
+No usar claims que la app no pueda sostener, como `ahorro garantizado`, `reduce tu factura` o `datos reales de consumo`, salvo que existan funcionalidades y evidencia suficiente.
+
+## Capturas recomendadas
+
+### Screenshot 1 — Decisión inmediata
+
+Mensaje:
+
+```text
+Sabe si ahora es buen momento para consumir
+```
+
+Pantalla: tab `Precios`, mostrando precio actual, mínimo, máximo y semáforo horario.
+
+### Screenshot 2 — Horas baratas del día
+
+Mensaje:
+
+```text
+Encuentra las horas más baratas sin leer tablas
+```
+
+Pantalla: listado horario con clasificación barata/media/cara.
+
+### Screenshot 3 — Evolución por tramos
+
+Mensaje:
+
+```text
+Compara mañana, tarde y noche de un vistazo
+```
+
+Pantalla: tab `Gráfica` con selector de tramo.
+
+### Screenshot 4 — Coste estimado
+
+Mensaje:
+
+```text
+Calcula cuánto puede costar usar un electrodoméstico
+```
+
+Pantalla: modal de cálculo.
+
+### Screenshot 5 — Avisos locales
+
+Mensaje:
+
+```text
+Recibe avisos antes de las mejores o peores horas
+```
+
+Pantalla: ajustes de notificaciones.
+
+## Monetización recomendada
+
+### Modelo inicial
+
+`Freemium` con posible compra única Pro.
+
+La app no debería cobrar por el simple acceso al precio horario, porque ese dato se percibe como público y sustituible.
+
+El pago debe asociarse a:
+
+- personalización;
+- automatización;
+- mejores estimaciones;
+- histórico ampliado;
+- widgets;
+- alertas inteligentes;
+- perfiles de electrodoméstico.
+
+### Gratis
+
+- Precio actual.
+- Resumen diario.
+- Lista horaria.
+- Gráfica básica.
+- Cálculo estimado básico.
+- Avisos esenciales limitados.
+
+### Pro
+
+- Alertas inteligentes ilimitadas.
+- Electrodomésticos personalizados.
+- Consumo por ciclo desde etiqueta energética.
+- Cálculo multi-hora.
+- Histórico ampliado.
+- Widgets avanzados.
+- Comparativas semanales o mensuales.
+
+## Precisión y claims
+
+### Claims permitidos
+
+- `precio horario`;
+- `estimación de coste`;
+- `avisos locales`;
+- `ayuda a decidir`;
+- `identifica horas baratas`.
+
+### Claims a evitar
+
+- `consumo real` si no hay medición externa;
+- `ahorro garantizado`;
+- `reduce tu factura automáticamente`;
+- `datos exactos de electrodomésticos`;
+- `optimización energética inteligente` si solo hay reglas simples.
+
+### Copy recomendado para cálculo
+
+```text
+El coste mostrado es una estimación basada en precio horario, potencia o consumo configurado y duración. El consumo real puede variar según modelo, programa, carga y condiciones de uso.
+```
+
+## Roadmap de posicionamiento
+
+### MVP comercial
+
+- README y ficha de App Store orientados a decisión.
+- Screenshots comerciales.
+- Onboarding simple.
+- Copy claro para notificaciones.
+- Disclaimer de estimaciones.
+
+### Pro inicial
+
+- Perfiles personalizados de electrodoméstico.
+- Consumo por ciclo desde etiqueta energética.
+- Más alertas.
+- Widgets.
+
+### Evolución avanzada
+
+- Escaneo de etiqueta energética.
+- Catálogo de modelos.
+- Integración con medidores compatibles.
+- Home Assistant.
+- Análisis de ahorro estimado.
+
+## Principio de comunicación
+
+Hablar siempre de `decidir mejor`, no de `garantizar ahorro`.
+
+La app debe transmitir claridad, control y rapidez:
+
+> abrir, mirar, decidir.


### PR DESCRIPTION
## Summary

- Rewrites the README to position PrecioLuzApp as a decision-oriented iPhone app for Spanish electricity prices, not just a price table.
- Adds clearer product value, target user, differentiation, App Store positioning, monetization direction, and data-precision messaging.
- Adds `docs/app-store-positioning.md` with ASO copy, suggested subtitles, screenshots, monetization model, claims to avoid, and roadmap for commercial positioning.

## Notes

- Documentation-only change.
- No code, project configuration, dependencies, or runtime behavior changed.
- The branch is currently based on the latest available commit when created and is 1 commit behind `main` at PR creation time.

## Validation

- Not run: documentation-only update.