### PR TITLE
Improve English README marketing positioning and App Store strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,34 +94,6 @@ Natural product evolutions include:
 - multi-hour calculation when an appliance cycle crosses hourly slots;
 - future integration with real measurements through smart plugs, Home Assistant, or compatible standards.
 
-## App Store positioning
-
-Recommended positioning:
-
-> Save attention, not only cents: check electricity prices, find the best hours, and get useful alerts from your iPhone.
-
-Subtitle candidates:
-
-- `Electricity prices and alerts`
-- `Find today’s cheapest hours`
-- `Decide when to use electricity`
-- `PVPC prices, charts, and alerts`
-
-Main promise:
-
-> Understand hourly electricity prices and make better decisions about when to use your appliances.
-
-See the extended strategy in [`docs/app-store-positioning.md`](docs/app-store-positioning.md).
-
-## Monetization direction
-
-The app is best suited to a `freemium` model:
-
-- a free version for daily price lookup, summaries, basic charts, and essential alerts;
-- a Pro version for advanced personalization, smart alerts, widgets, appliance profiles, extended history, and better cost estimates.
-
-The app should not monetize simple access to public hourly price data. Paid value should live in the decision layer: recommendations, personalization, automation, widgets, and analysis.
-
 ## Technical stack
 
 - `SwiftUI`
@@ -150,7 +122,7 @@ The shared Xcode scheme only stores `PRECIOLUZ_ENV_FILE=$(SRCROOT)/.env`, which 
 
 - [`AGENTS.md`](AGENTS.md) — project governance, boundaries, and priorities.
 - [`docs/product-spec.md`](docs/product-spec.md) — functional product contract.
-- [`docs/app-store-positioning.md`](docs/app-store-positioning.md) — positioning, ASO, screenshots, and monetization direction.
+- [`docs/app-store-positioning.md`](docs/app-store-positioning.md) — App Store positioning, ASO, screenshots, and monetization direction.
 - [`docs/ios-architecture.md`](docs/ios-architecture.md) — technical structure and planned responsibilities.
 - [`docs/engineering-rules.md`](docs/engineering-rules.md) — execution, validation, CI, and PR rules.
 - [`docs/ui-direction.md`](docs/ui-direction.md) — visual and UX direction.

--- a/README.md
+++ b/README.md
@@ -1,60 +1,128 @@
 # PrecioLuzApp ⚡📱
 
-> A native iPhone app to understand electricity prices at a glance, explore daily trends, and get smart local alerts before expensive hours hit.
+> A native iPhone app that helps people in Spain decide **when it is worth using electricity** without reading complex price tables.
 
-## ✨ What is this project?
+`PrecioLuzApp` helps domestic users with PVPC or indexed electricity tariffs understand hourly electricity prices, spot the best hours of the day, and receive useful local alerts before expensive or convenient time slots arrive.
 
-`PrecioLuzApp` is an iPhone-first app focused on Spanish hourly electricity pricing.
+The product goal is not only to display prices. The goal is to turn hourly market data into simple everyday decisions.
 
-The goal is simple:
+## Value proposition
 
-- 🟢 show when electricity is cheap
-- 🟠 highlight mid-range hours
-- 🔴 warn when prices are expensive
-- 🧮 help users estimate appliance cost from a selected hour
-- 🔔 schedule local notifications for daily minimums, maximums, and custom thresholds
+- See the current electricity price in seconds.
+- Quickly identify cheap, mid-range, and expensive hours.
+- Compare the daily price curve by time segment.
+- Estimate appliance usage cost from a selected hour.
+- Receive local alerts for daily minimums, maximums, and custom thresholds.
+- Stay iPhone-first, privacy-conscious, and simple: no account and no backend in the base scope.
 
-This project is also intentionally being used as a learning playground for:
+## Target user
 
-- 🧩 The Composable Architecture (`TCA`)
-- 🍎 modern native iOS development
-- 🪟 SwiftUI-first UI patterns
-- 🧪 testable feature design
+`PrecioLuzApp` is designed for people in Spain who check electricity prices during the day and want to make better decisions about when to use appliances such as washing machines, dishwashers, water heaters, cooking devices, or climate control.
 
-## 📲 Planned app experience
+The main user job is simple:
 
-The app is designed around **three tabs**:
+> “I want to know at a glance whether now is a good time to use electricity or whether I should wait.”
+
+## Core app experience
+
+The app is organized around three tabs:
 
 ### 1. Prices ⏰
-- Daily summary cards for current, average, minimum, and maximum price
-- A 24-hour price list
-- Color-coded hourly slots for cheap, mid, and expensive periods
-- A modal cost calculator when the user taps a time slot
+
+Fast daily reading:
+
+- summary cards for current, average, minimum, and maximum price;
+- complete hourly price list;
+- visual classification for cheap, mid-range, and expensive slots;
+- current-hour highlighting;
+- access to an estimated appliance cost calculation from any selected hourly slot.
 
 ### 2. Chart 📈
-- A daily chart split into clear day sections
-- Fast visual comparison between time ranges
-- Hourly inspection for a selected time segment
+
+Visual price exploration:
+
+- native `Charts` daily graph;
+- fixed daypart segmentation: overnight, morning, afternoon, and night;
+- point inspection for a selected hour;
+- quick comparison between different parts of the day.
 
 ### 3. Settings ⚙️
-- Local notification toggles
-- Daily minimum alert
-- Daily maximum alert
-- Custom price-threshold alert
 
-## 🧠 Product direction
+Local alert control:
 
-The current product definition assumes:
+- notification enablement;
+- daily minimum alert;
+- daily maximum alert;
+- custom threshold alert in `€/kWh`.
 
-- 🇪🇸 Spanish market pricing with `ESIOS/PVPC` as the initial source of truth
-- 📆 up to `30 days` of local history
-- 🔔 local notifications only
-- 📱 iPhone-only scope for the base version
-- 🌙 a dark, modern, native iOS visual direction
+## Product differentiation
 
-## 🏗️ Tech direction
+Many tools show electricity prices. `PrecioLuzApp` aims to differentiate through:
 
-The project documentation currently defines this stack:
+- **immediate clarity**: hourly traffic-light semantics and daily summary without noise;
+- **actionable decisions**: knowing when to consume, not only how much electricity costs;
+- **native iOS quality**: SwiftUI, Charts, functional motion, and a modern dark visual direction;
+- **privacy and simplicity**: no login, no account, and no own backend in the base scope;
+- **local alerts**: daily utility without relying on remote push notifications.
+
+## Current scope
+
+The current implementation is positioned as an advanced MVP foundation:
+
+- ✅ iPhone project generated with `XcodeGen`;
+- ✅ architecture based on `SwiftUI`, `TCA`, and `Swift Concurrency`;
+- ✅ `Prices`, `Chart`, and `Settings` tabs;
+- ✅ domain models and injectable clients;
+- ✅ `REE/ESIOS` data integration through a local API key;
+- ✅ local persistence and recent history;
+- ✅ estimated appliance cost calculation;
+- ✅ local notifications for daily minimum, daily maximum, and threshold alerts;
+- ✅ resilience states: loading, empty, error, cached, and retry;
+- ✅ test coverage, snapshots, and UI smoke tests;
+- ✅ CI workflow for `build` and `test`.
+
+## Data and precision
+
+The app uses `REE/ESIOS` as the initial source of truth for Spanish hourly electricity prices.
+
+Appliance cost calculation is currently an estimate based on power and duration. This is valid for MVP validation, but it should not be presented as real measured consumption.
+
+Natural product evolutions include:
+
+- custom appliance profiles;
+- energy-per-cycle values entered from energy labels;
+- multi-hour calculation when an appliance cycle crosses hourly slots;
+- future integration with real measurements through smart plugs, Home Assistant, or compatible standards.
+
+## App Store positioning
+
+Recommended positioning:
+
+> Save attention, not only cents: check electricity prices, find the best hours, and get useful alerts from your iPhone.
+
+Subtitle candidates:
+
+- `Electricity prices and alerts`
+- `Find today’s cheapest hours`
+- `Decide when to use electricity`
+- `PVPC prices, charts, and alerts`
+
+Main promise:
+
+> Understand hourly electricity prices and make better decisions about when to use your appliances.
+
+See the extended strategy in [`docs/app-store-positioning.md`](docs/app-store-positioning.md).
+
+## Monetization direction
+
+The app is best suited to a `freemium` model:
+
+- a free version for daily price lookup, summaries, basic charts, and essential alerts;
+- a Pro version for advanced personalization, smart alerts, widgets, appliance profiles, extended history, and better cost estimates.
+
+The app should not monetize simple access to public hourly price data. Paid value should live in the decision layer: recommendations, personalization, automation, widgets, and analysis.
+
+## Technical stack
 
 - `SwiftUI`
 - `Swift Concurrency`
@@ -63,47 +131,35 @@ The project documentation currently defines this stack:
 - `URLSession`
 - `The Composable Architecture`
 - `sqlite-data`
+- `SnapshotTesting`
+- `XcodeGen`
 
-## 🔐 Local REE/ESIOS API key
+## Local REE/ESIOS API key
 
-Real REE/ESIOS data is loaded from the local `REE_API_KEY` secret. The key must not be committed.
+Real `REE/ESIOS` data is loaded from the local `REE_API_KEY` secret. The key must not be committed.
 
-For local development, create a repo-root `.env` file and add the `REE_API_KEY` entry with your local token.
+For local development, create a repo-root `.env` file:
 
-The shared Xcode scheme only stores `PRECIOLUZ_ENV_FILE=$(SRCROOT)/.env`, which is a non-secret path. Unit tests read that local file when the variable is not already present in the process environment.
+```env
+REE_API_KEY=your_local_token
+```
 
-For simulator Debug app runs, XcodeGen config copies the local `.env` into the built app bundle as `PrecioLuzLocal.env`. That generated bundle resource is local build output only; it is not tracked and is removed for non-Debug configurations.
+The shared Xcode scheme only stores `PRECIOLUZ_ENV_FILE=$(SRCROOT)/.env`, which is a non-secret local path. For simulator Debug runs, `XcodeGen` copies the local `.env` into the built app bundle as `PrecioLuzLocal.env`. That generated bundle resource is local build output only; it is not tracked and is removed for non-Debug configurations.
 
-## 🚧 Current status
+## Documentation
 
-Roadmap implementation is currently delivered through `Milestone 8` at local-repo level:
+- [`AGENTS.md`](AGENTS.md) — project governance, boundaries, and priorities.
+- [`docs/product-spec.md`](docs/product-spec.md) — functional product contract.
+- [`docs/app-store-positioning.md`](docs/app-store-positioning.md) — positioning, ASO, screenshots, and monetization direction.
+- [`docs/ios-architecture.md`](docs/ios-architecture.md) — technical structure and planned responsibilities.
+- [`docs/engineering-rules.md`](docs/engineering-rules.md) — execution, validation, CI, and PR rules.
+- [`docs/ui-direction.md`](docs/ui-direction.md) — visual and UX direction.
+- [`docs/implementation-roadmap.md`](docs/implementation-roadmap.md) — implementation roadmap.
+- [`docs/validation-evidence.md`](docs/validation-evidence.md) — validation evidence.
+- [`docs/codex-project-prompt.md`](docs/codex-project-prompt.md) — lightweight execution prompt template.
 
-- ✅ iPhone Xcode project generated via `project.yml` (`XcodeGen`)
-- ✅ `TCA` + `sqlite-data` dependencies integrated
-- ✅ base `TabView` shell with `Precios`, `Gráfica`, `Ajustes`
-- ✅ SF Symbols configured for tabs (`eurosign.circle`, `chart.xyaxis.line`, `gearshape`)
-- ✅ localized tab titles via `Localizable.strings` (`es` and `en`)
-- ✅ domain models + injectable clients (`pricing`, `persistence`, `date`, `notifications`)
-- ✅ `Prices`, `Chart`, `Settings`, and `CostCalculation` features
-- ✅ resilience + QA hardening baseline (`offline/cached/error/retry`) with acceptance/snapshot/ui smoke coverage
-- ✅ baseline shell tests + TCA smoke tests
-- ✅ GitHub Actions CI workflow for `build` + `test`
-- ✅ validation evidence documented up to `Issue #11` final checkpoint in `docs/validation-evidence.md`
+## Product principle
 
-Pending roadmap work is now mainly integration traceability (`Done-Integrated`) and follow-up increments/issues after milestone closure.
+`PrecioLuzApp` should not feel like a price table. It should feel like a fast decision:
 
-## 📚 Documentation map
-
-If you want the full project definition, start here:
-
-- `AGENTS.md` — project governance, boundaries, and priorities
-- `docs/product-spec.md` — functional product contract
-- `docs/ios-architecture.md` — technical structure and planned folder responsibilities
-- `docs/engineering-rules.md` — execution rules for implementation work
-- `docs/ui-direction.md` — visual and UX direction
-- `docs/implementation-roadmap.md` — step-by-step delivery roadmap
-- `docs/codex-project-prompt.md` — lightweight execution prompt template
-
----
-
-Built with ⚡ energy data, 📱 native iOS ideas, and 🧠 a strong bias toward clarity.
+> “Use electricity now”, “wait”, or “choose this cheaper slot”.

--- a/docs/app-store-positioning.md
+++ b/docs/app-store-positioning.md
@@ -1,0 +1,297 @@
+# App Store Positioning
+
+## Goal
+
+Define a commercial positioning baseline for `PrecioLuzApp` before preparing App Store metadata, screenshots, paywall copy, or future monetization decisions.
+
+The app should be positioned as a domestic decision tool, not as a simple electricity price table.
+
+## Core positioning
+
+`PrecioLuzApp` helps people in Spain decide when it is worth using electricity during the day, using hourly prices, fast visual reading, and local alerts.
+
+### Positioning statement
+
+> Check hourly electricity prices, find the best hours of the day, and receive useful alerts before you consume.
+
+### Product promise
+
+> Understand electricity prices in seconds and make better decisions about when to use your appliances.
+
+### Key message
+
+The product is not only about seeing prices. It is about turning hourly data into simple decisions:
+
+- now is a good time;
+- better wait;
+- this is the cheap slot;
+- avoid this expensive slot;
+- enable an alert and stop checking manually.
+
+## Target audience
+
+### Primary user
+
+People in Spain with PVPC, indexed electricity tariffs, or high sensitivity to hourly electricity prices.
+
+Needs:
+
+- check the current price quickly;
+- find cheap hours without reading dense tables;
+- receive alerts before the best or worst hours;
+- estimate how much using an appliance could cost;
+- avoid complex setup, accounts, or external systems.
+
+### Main use cases
+
+| Use case | User need | App response |
+|---|---|---|
+| Run a washing machine | Know whether to run it now or later | Current price + cheap hours |
+| Cook or use high-consumption appliances | Avoid an expensive time slot | Hourly list + daily maximum |
+| Plan daily usage | Find an available cheap period | Daypart chart |
+| Daily monitoring | Avoid checking the app every hour | Local notifications |
+| Estimate cost | Understand approximate usage impact | Appliance cost calculator |
+
+## Value proposition
+
+### Functional value
+
+- Spanish hourly electricity prices.
+- Daily summary: current, average, minimum, and maximum.
+- Hourly traffic-light semantics for cheap, mid-range, and expensive slots.
+- Daily chart split by dayparts.
+- Estimated appliance cost calculation.
+- Configurable local alerts.
+
+### Emotional value
+
+- Less uncertainty.
+- More control over domestic electricity usage.
+- Less dependency on websites or dense tables.
+- A clearer sense of making better decisions with little effort.
+
+### Differentiation
+
+- Native iPhone experience.
+- No account in the base scope.
+- No own backend in the base scope.
+- Dark visual direction and fast reading.
+- Local alerts focused on utility, not artificial engagement.
+
+## App Store messaging
+
+### Name
+
+Current development name:
+
+```text
+PrecioLuzApp
+```
+
+It is clear for development, but a more natural commercial name could be evaluated before release.
+
+Possible names:
+
+- `Precio Luz`
+- `Precio Luz España`
+- `Luz Horaria`
+- `Luz Hoy`
+- `Ahorra Luz`
+
+Criterion: prioritize ASO clarity over originality.
+
+### Subtitle candidates
+
+- `Electricity prices and alerts`
+- `Find today’s cheapest hours`
+- `Decide when to use electricity`
+- `PVPC prices, charts, and alerts`
+- `Smarter electricity timing`
+
+### Promotional text
+
+```text
+Check hourly electricity prices in Spain, find the cheapest hours, and receive alerts to decide better when to use electricity.
+```
+
+### Short description
+
+```text
+PrecioLuzApp helps you understand hourly electricity prices in Spain. Check the current price, find the cheapest hours of the day, review the daily curve by time segment, and enable local alerts for daily minimums, maximums, or custom thresholds.
+```
+
+### Extended description
+
+```text
+PrecioLuzApp turns hourly electricity prices into a simple decision.
+
+See at a glance how much electricity costs right now, what the daily minimum and maximum are, and which hours are more convenient for using your appliances.
+
+The app shows a clear hourly list, a daily chart by time segment, and an estimated appliance cost calculator to help you understand the impact of using electricity at a specific hour.
+
+You can also enable local alerts before the best or worst slots, without creating an account and without relying on remote push notifications.
+```
+
+## ASO keywords
+
+> Pending real validation in App Store Connect and competitive analysis.
+
+Initial keyword ideas:
+
+```text
+electricity price, hourly electricity, PVPC, Spain electricity, electricity alerts, cheap electricity, electricity tariff, energy savings, light price, power price
+```
+
+Spanish-market metadata should also evaluate localized keywords such as:
+
+```text
+precio luz, luz hoy, PVPC, electricidad, tarifa luz, luz barata, precio electricidad, ahorro luz, hora barata, factura luz
+```
+
+Avoid claims the app cannot support, such as `guaranteed savings`, `reduce your bill`, or `real appliance consumption`, unless the corresponding functionality and evidence exist.
+
+## Recommended screenshots
+
+### Screenshot 1 — Immediate decision
+
+Message:
+
+```text
+Know whether now is a good time to consume
+```
+
+Screen: `Prices` tab with current price, minimum, maximum, and hourly traffic-light semantics.
+
+### Screenshot 2 — Cheapest hours
+
+Message:
+
+```text
+Find the cheapest hours without reading tables
+```
+
+Screen: hourly list with cheap, mid-range, and expensive classification.
+
+### Screenshot 3 — Daily curve
+
+Message:
+
+```text
+Compare morning, afternoon, and night at a glance
+```
+
+Screen: `Chart` tab with daypart picker.
+
+### Screenshot 4 — Estimated cost
+
+Message:
+
+```text
+Estimate how much an appliance could cost
+```
+
+Screen: calculation sheet.
+
+### Screenshot 5 — Local alerts
+
+Message:
+
+```text
+Get alerts before the best or worst hours
+```
+
+Screen: notification settings.
+
+## Monetization recommendation
+
+### Initial model
+
+`Freemium` with a possible one-time Pro unlock.
+
+The app should not charge for simple access to hourly price data, because that data is perceived as public and replaceable.
+
+Paid value should be associated with:
+
+- personalization;
+- automation;
+- better estimates;
+- extended history;
+- widgets;
+- smart alerts;
+- appliance profiles.
+
+### Free tier
+
+- Current price.
+- Daily summary.
+- Hourly list.
+- Basic chart.
+- Basic estimated cost calculation.
+- Limited essential alerts.
+
+### Pro tier
+
+- Unlimited smart alerts.
+- Custom appliance profiles.
+- Energy-per-cycle values from energy labels.
+- Multi-hour cost calculation.
+- Extended history.
+- Advanced widgets.
+- Weekly or monthly comparisons.
+
+## Precision and claims
+
+### Safe claims
+
+- `hourly electricity prices`;
+- `estimated cost`;
+- `local alerts`;
+- `helps you decide`;
+- `find cheap hours`.
+
+### Claims to avoid
+
+- `real consumption` without external measurement;
+- `guaranteed savings`;
+- `automatically reduces your bill`;
+- `exact appliance consumption`;
+- `intelligent energy optimization` if the app only uses simple deterministic rules.
+
+### Recommended calculation copy
+
+```text
+The displayed cost is an estimate based on hourly price, configured power or energy usage, and duration. Real consumption may vary depending on model, program, load, and usage conditions.
+```
+
+## Positioning roadmap
+
+### Commercial MVP
+
+- README and App Store metadata focused on decision-making.
+- Commercial screenshots.
+- Simple onboarding.
+- Clear notification copy.
+- Estimation disclaimer.
+
+### Initial Pro layer
+
+- Custom appliance profiles.
+- Energy-per-cycle values from energy labels.
+- More alerts.
+- Widgets.
+
+### Advanced evolution
+
+- Energy label scanning.
+- Appliance model catalog.
+- Integration with compatible meters.
+- Home Assistant.
+- Estimated savings analysis.
+
+## Communication principle
+
+Always communicate `making better decisions`, not `guaranteed savings`.
+
+The app should convey clarity, control, and speed:
+
+> open, read, decide.


### PR DESCRIPTION
## Summary

- Rewrites the README in English to position PrecioLuzApp as a decision-oriented iPhone app for Spanish electricity prices, not just a price table.
- Adds clearer product value, target user, differentiation, App Store positioning, monetization direction, and data-precision messaging.
- Adds `docs/app-store-positioning.md` in English with ASO copy, suggested subtitles, screenshot strategy, monetization model, safe claims, claims to avoid, and commercial roadmap.

## Notes

- Documentation-only change.
- Branch created from the current `main` commit after pulling main context.
- No code, project configuration, dependencies, or runtime behavior changed.
- Supersedes closed PR #51, which used Spanish copy and was based on an older branch.

## Validation

- Not run: documentation-only update.