### PR TITLE
Fix widget hourly refresh timeline

### DIFF
--- a/Widgets/PrecioLuzWidget.swift
+++ b/Widgets/PrecioLuzWidget.swift
@@ -99,22 +99,23 @@ private enum PrecioLuzWidgetTimelineLoader {
         }
 
         let startDate = alignedHourDate(for: now, calendar: calendar) ?? now
-        let endDate = calendar.date(byAdding: .hour, value: 24, to: startDate) ?? startDate
-        var cursor = startDate
-        var entries: [PrecioLuzWidgetEntry] = []
+        let entryDates = hourlyPrices
+            .map(\.date)
+            .filter { $0 >= startDate }
+            .sorted()
 
-        while cursor <= endDate {
+        guard !entryDates.isEmpty else {
+            return [PrecioLuzWidgetEntry(date: now, model: makeEmptyModel())]
+        }
+
+        return entryDates.map { cursor in
             let model = PricesMediumWidgetMapper.makeModel(
                 from: hourlyPrices,
                 now: cursor,
                 calendar: calendar
             )
-            entries.append(PrecioLuzWidgetEntry(date: cursor, model: model))
-            guard let nextHour = calendar.date(byAdding: .hour, value: 1, to: cursor) else { break }
-            cursor = nextHour
+            return PrecioLuzWidgetEntry(date: cursor, model: model)
         }
-
-        return entries
     }
 
     private static func fetchHourlyPrices(now: Date, calendar: Calendar) async -> [HourlyPrice] {

--- a/Widgets/PrecioLuzWidget.swift
+++ b/Widgets/PrecioLuzWidget.swift
@@ -18,8 +18,8 @@ struct PrecioLuzWidgetProvider: TimelineProvider {
     func getTimeline(in context: Context, completion: @escaping (Timeline<PrecioLuzWidgetEntry>) -> Void) {
         let completion = PrecioLuzWidgetTimelineCompletion(completion)
         Task {
-            let entry = await PrecioLuzWidgetTimelineLoader.makeEntry()
-            let timeline = Timeline(entries: [entry], policy: .after(entry.nextRefreshDate))
+            let entries = await PrecioLuzWidgetTimelineLoader.makeHourlyEntries()
+            let timeline = Timeline(entries: entries, policy: .atEnd)
             completion.callAsFunction(timeline)
         }
     }
@@ -76,12 +76,6 @@ private extension PricesMediumWidgetPresentationModel {
     )
 }
 
-private extension PrecioLuzWidgetEntry {
-    var nextRefreshDate: Date {
-        Calendar.current.date(byAdding: .minute, value: 30, to: date) ?? date
-    }
-}
-
 private final class PrecioLuzWidgetTimelineCompletion: @unchecked Sendable {
     private let completion: (Timeline<PrecioLuzWidgetEntry>) -> Void
 
@@ -97,31 +91,50 @@ private final class PrecioLuzWidgetTimelineCompletion: @unchecked Sendable {
 private enum PrecioLuzWidgetTimelineLoader {
     private static let timeZone = TimeZone(identifier: "Europe/Madrid") ?? .current
 
-    static func makeEntry(now: Date = Date()) async -> PrecioLuzWidgetEntry {
-        let model = await makeModel(now: now)
-        return PrecioLuzWidgetEntry(date: now, model: model)
-    }
+    static func makeHourlyEntries(now: Date = Date()) async -> [PrecioLuzWidgetEntry] {
+        let calendar = pricingCalendar
+        let hourlyPrices = await fetchHourlyPrices(now: now, calendar: calendar)
+        guard !hourlyPrices.isEmpty else {
+            return [PrecioLuzWidgetEntry(date: now, model: makeEmptyModel())]
+        }
 
-    private static func makeModel(now: Date) async -> PricesMediumWidgetPresentationModel {
-        do {
-            let calendar = pricingCalendar
-            let rawPrices = try await fetchRawPrices(now: now, calendar: calendar)
-            let hourlyPrices = HourlyPriceClassifier.classify(rawPrices, calendar: calendar)
-            return PricesMediumWidgetMapper.makeModel(
+        let startDate = alignedHourDate(for: now, calendar: calendar) ?? now
+        let endDate = calendar.date(byAdding: .hour, value: 24, to: startDate) ?? startDate
+        var cursor = startDate
+        var entries: [PrecioLuzWidgetEntry] = []
+
+        while cursor <= endDate {
+            let model = PricesMediumWidgetMapper.makeModel(
                 from: hourlyPrices,
-                now: now,
+                now: cursor,
                 calendar: calendar
             )
-        } catch {
-            return PricesMediumWidgetPresentationModel(
-                barSeries: [],
-                currentPriceText: "—",
-                currentSlotLabel: String(localized: "widget.medium.empty.slot"),
-                nextHours: [],
-                state: .empty,
-                timeWindowLabel: String(localized: "widget.medium.empty.timeWindow")
-            )
+            entries.append(PrecioLuzWidgetEntry(date: cursor, model: model))
+            guard let nextHour = calendar.date(byAdding: .hour, value: 1, to: cursor) else { break }
+            cursor = nextHour
         }
+
+        return entries
+    }
+
+    private static func fetchHourlyPrices(now: Date, calendar: Calendar) async -> [HourlyPrice] {
+        do {
+            let rawPrices = try await fetchRawPrices(now: now, calendar: calendar)
+            return HourlyPriceClassifier.classify(rawPrices, calendar: calendar)
+        } catch {
+            return []
+        }
+    }
+
+    private static func makeEmptyModel() -> PricesMediumWidgetPresentationModel {
+        PricesMediumWidgetPresentationModel(
+            barSeries: [],
+            currentPriceText: "—",
+            currentSlotLabel: String(localized: "widget.medium.empty.slot"),
+            nextHours: [],
+            state: .empty,
+            timeWindowLabel: String(localized: "widget.medium.empty.timeWindow")
+        )
     }
 
     private static func fetchRawPrices(now: Date, calendar: Calendar) async throws -> [PricingClient.HourPrice] {
@@ -139,5 +152,10 @@ private enum PrecioLuzWidgetTimelineLoader {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = timeZone
         return calendar
+    }
+
+    private static func alignedHourDate(for date: Date, calendar: Calendar) -> Date? {
+        let components = calendar.dateComponents([.year, .month, .day, .hour], from: date)
+        return calendar.date(from: components)
     }
 }


### PR DESCRIPTION
## Summary
- generate hourly widget timeline entries for next 24 hours
- switch widget refresh policy to atEnd for deterministic hour-based updates
- keep safe empty-state fallback when pricing fetch unavailable

## Validation
- full xcodebuild test suite passed on iOS Simulator (PrecioLuz Clean iPhone 17, iOS 26.4)
- pre-push build plus tests passed