### PR TITLE
Fix live hourly price presentation

### DIFF
--- a/Sources/Features/PricesFeature/PricesFeature.swift
+++ b/Sources/Features/PricesFeature/PricesFeature.swift
@@ -1,14 +1,14 @@
 import ComposableArchitecture
 import Foundation
 
+enum HourlyListPresentationMode: String, CaseIterable, Equatable {
+    case flatWithAvailabilityNotice
+    case withDateHeaders
+}
+
 struct PricesFeature: Reducer {
     @ObservableState
     struct State: Equatable {
-        enum HourlyListPresentationMode: String, CaseIterable, Equatable {
-            case flatWithAvailabilityNotice
-            case withDateHeaders
-        }
-
         var costCalculation = CostCalculationFeature.State()
         var hourlyListPresentationMode: HourlyListPresentationMode = .withDateHeaders
         var hourlyPrices: [HourlyPrice] = []
@@ -67,9 +67,32 @@ extension PricesFeature.State {
         visibleHourlyPrices.contains { $0.date == hour.date }
     }
 
+    func presentationCurrentHourDate(now: Date, calendar: Calendar) -> Date? {
+        hourlyPrices.first { calendar.isDate($0.date, equalTo: now, toGranularity: .hour) }?.date
+    }
+
+    func presentationNow(timelineDate: Date, calendar: Calendar) -> Date {
+        guard hasPrices(forSameDayAs: timelineDate, calendar: calendar) else {
+            return summary?.current?.date ?? hourlyPrices.first?.date ?? timelineDate
+        }
+        return timelineDate
+    }
+
+    func presentationVisibleHourlyPrices(now: Date, calendar: Calendar) -> [HourlyPrice] {
+        guard hasPrices(forSameDayAs: now, calendar: calendar) else {
+            return visibleHourlyPrices
+        }
+        let currentHourStart = calendar.dateInterval(of: .hour, for: now)?.start ?? now
+        return hourlyPrices.filter { $0.date >= currentHourStart }
+    }
+
     mutating func refreshVisibleHours(now: Date, calendar: Calendar) {
         let currentHourStart = calendar.dateInterval(of: .hour, for: now)?.start ?? now
         visibleHourlyPrices = hourlyPrices.filter { $0.date >= currentHourStart }
+    }
+
+    private func hasPrices(forSameDayAs date: Date, calendar: Calendar) -> Bool {
+        hourlyPrices.contains { calendar.isDate($0.date, inSameDayAs: date) }
     }
 
     private mutating func reconcileSelectedHour() {

--- a/Sources/Features/PricesFeature/PricesFeature.swift
+++ b/Sources/Features/PricesFeature/PricesFeature.swift
@@ -72,16 +72,10 @@ extension PricesFeature.State {
     }
 
     func presentationNow(timelineDate: Date, calendar: Calendar) -> Date {
-        guard hasPrices(forSameDayAs: timelineDate, calendar: calendar) else {
-            return summary?.current?.date ?? hourlyPrices.first?.date ?? timelineDate
-        }
         return timelineDate
     }
 
     func presentationVisibleHourlyPrices(now: Date, calendar: Calendar) -> [HourlyPrice] {
-        guard hasPrices(forSameDayAs: now, calendar: calendar) else {
-            return visibleHourlyPrices
-        }
         let currentHourStart = calendar.dateInterval(of: .hour, for: now)?.start ?? now
         return hourlyPrices.filter { $0.date >= currentHourStart }
     }
@@ -89,10 +83,6 @@ extension PricesFeature.State {
     mutating func refreshVisibleHours(now: Date, calendar: Calendar) {
         let currentHourStart = calendar.dateInterval(of: .hour, for: now)?.start ?? now
         visibleHourlyPrices = hourlyPrices.filter { $0.date >= currentHourStart }
-    }
-
-    private func hasPrices(forSameDayAs date: Date, calendar: Calendar) -> Bool {
-        hourlyPrices.contains { calendar.isDate($0.date, inSameDayAs: date) }
     }
 
     private mutating func reconcileSelectedHour() {

--- a/Sources/Features/PricesFeature/PricesHourlyListSectionView.swift
+++ b/Sources/Features/PricesFeature/PricesHourlyListSectionView.swift
@@ -9,7 +9,7 @@ struct PricesHourlyListSectionView: View {
     let currentDate: Date?
     let emptyMessage: LocalizedStringResource
     let entranceTrigger: Bool
-    let hourlyListPresentationMode: PricesFeature.State.HourlyListPresentationMode
+    let hourlyListPresentationMode: HourlyListPresentationMode
     let hourlyPrices: [HourlyPrice]
     let onHourTapped: (HourlyPrice) -> Void
 
@@ -17,7 +17,7 @@ struct PricesHourlyListSectionView: View {
         currentDate: Date?,
         emptyMessage: LocalizedStringResource = "prices.hourly.empty",
         entranceTrigger: Bool,
-        hourlyListPresentationMode: PricesFeature.State.HourlyListPresentationMode,
+        hourlyListPresentationMode: HourlyListPresentationMode,
         hourlyPrices: [HourlyPrice],
         onHourTapped: @escaping (HourlyPrice) -> Void
     ) {

--- a/Sources/Features/PricesFeature/PricesView.swift
+++ b/Sources/Features/PricesFeature/PricesView.swift
@@ -7,7 +7,17 @@ struct PricesView: View {
     let state: PricesFeature.State
 
     var body: some View {
-        ScrollView {
+        TimelineView(.periodic(from: Date(), by: Constants.timelineRefreshInterval)) { context in
+            content(timelineDate: context.date)
+        }
+    }
+
+    private func content(timelineDate: Date) -> some View {
+        let calendar = Calendar.current
+        let presentationNow = state.presentationNow(timelineDate: timelineDate, calendar: calendar)
+        let presentationHourlyPrices = state.presentationVisibleHourlyPrices(now: timelineDate, calendar: calendar)
+
+        return ScrollView {
             VStack(alignment: .leading, spacing: PricesViewLayout.verticalSpacing) {
                 if state.isLoading {
                     PricesLoadingSkeletonView()
@@ -17,36 +27,12 @@ struct PricesView: View {
                         .transition(.opacity)
                 }
 
-                if !state.isLoading {
-                    PricesMediumWidgetView(model: mediumWidgetModel)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .padding(.top, PricesViewLayout.widgetTopPadding)
-                        .accessibilityElement(children: .contain)
-                        .accessibilityIdentifier("pricesMediumWidgetContainer")
-                        .transition(.opacity.combined(with: .move(edge: .top)))
-
-                    if let summary = state.summary {
-                        PricesSummaryCardsView(
-                            entranceTrigger: contentEntranceTriggered,
-                            summary: summary
-                        )
-                    } else {
-                        noSummaryView
-                    }
-
-                    PricesHourlyListSectionView(
-                        currentDate: state.summary?.current?.date,
-                        emptyMessage: state.hourlyPrices.isEmpty
-                            ? "prices.hourly.empty"
-                            : "prices.hourly.noRemainingToday",
-                        entranceTrigger: contentEntranceTriggered,
-                        hourlyListPresentationMode: state.hourlyListPresentationMode,
-                        hourlyPrices: state.visibleHourlyPrices,
-                        onHourTapped: onHourTapped
-                    )
-                    .padding(.top, PricesViewLayout.sectionSpacing)
-                    .transition(.opacity.combined(with: .move(edge: .bottom)))
-                }
+                loadedContent(
+                    calendar: calendar,
+                    hourlyPrices: presentationHourlyPrices,
+                    now: presentationNow,
+                    timelineDate: timelineDate
+                )
             }
             .padding(PricesViewLayout.contentPadding)
         }
@@ -85,13 +71,60 @@ struct PricesView: View {
             .accessibilityIdentifier("pricesSummaryEmpty")
     }
 
-    private var mediumWidgetModel: PricesMediumWidgetPresentationModel {
-        let fallbackNow = state.hourlyPrices.first?.date ?? Date()
-        return PricesMediumWidgetMapper.makeModel(
+    @ViewBuilder
+    private func loadedContent(
+        calendar: Calendar,
+        hourlyPrices: [HourlyPrice],
+        now: Date,
+        timelineDate: Date
+    ) -> some View {
+        if !state.isLoading {
+            PricesMediumWidgetView(model: mediumWidgetModel(now: now, calendar: calendar))
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.top, PricesViewLayout.widgetTopPadding)
+                .accessibilityElement(children: .contain)
+                .accessibilityIdentifier("pricesMediumWidgetContainer")
+                .transition(.opacity.combined(with: .move(edge: .top)))
+
+            summaryContent
+
+            PricesHourlyListSectionView(
+                currentDate: state.presentationCurrentHourDate(now: timelineDate, calendar: calendar),
+                emptyMessage: state.hourlyPrices.isEmpty
+                    ? "prices.hourly.empty"
+                    : "prices.hourly.noRemainingToday",
+                entranceTrigger: contentEntranceTriggered,
+                hourlyListPresentationMode: state.hourlyListPresentationMode,
+                hourlyPrices: hourlyPrices,
+                onHourTapped: onHourTapped
+            )
+            .padding(.top, PricesViewLayout.sectionSpacing)
+            .transition(.opacity.combined(with: .move(edge: .bottom)))
+        }
+    }
+
+    private func mediumWidgetModel(now: Date, calendar: Calendar) -> PricesMediumWidgetPresentationModel {
+        PricesMediumWidgetMapper.makeModel(
             from: state.hourlyPrices,
-            now: state.summary?.current?.date ?? fallbackNow,
-            calendar: .current
+            now: now,
+            calendar: calendar
         )
+    }
+
+    private enum Constants {
+        static let timelineRefreshInterval: TimeInterval = 60
+    }
+
+    @ViewBuilder
+    private var summaryContent: some View {
+        if let summary = state.summary {
+            PricesSummaryCardsView(
+                entranceTrigger: contentEntranceTriggered,
+                summary: summary
+            )
+        } else {
+            noSummaryView
+        }
     }
 }
 

--- a/Sources/Features/PricesFeature/PricesView.swift
+++ b/Sources/Features/PricesFeature/PricesView.swift
@@ -5,10 +5,26 @@ struct PricesView: View {
 
     let onHourTapped: (HourlyPrice) -> Void
     let state: PricesFeature.State
+    let timelineDateOverride: Date?
 
+    init(
+        onHourTapped: @escaping (HourlyPrice) -> Void,
+        state: PricesFeature.State,
+        timelineDateOverride: Date? = nil
+    ) {
+        self.onHourTapped = onHourTapped
+        self.state = state
+        self.timelineDateOverride = timelineDateOverride
+    }
+
+    @ViewBuilder
     var body: some View {
-        TimelineView(.periodic(from: Date(), by: Constants.timelineRefreshInterval)) { context in
-            content(timelineDate: context.date)
+        if let timelineDateOverride {
+            content(timelineDate: timelineDateOverride)
+        } else {
+            TimelineView(.periodic(from: Date(), by: Constants.timelineRefreshInterval)) { context in
+                content(timelineDate: context.date)
+            }
         }
     }
 

--- a/Tests/Features/PricesFeatureTests.swift
+++ b/Tests/Features/PricesFeatureTests.swift
@@ -184,8 +184,8 @@ struct PricesFeatureTests {
         #expect(state.presentationCurrentHourDate(now: now, calendar: calendar) == payload.hourlyPrices[11].date)
     }
 
-    @Test("PricesFeature presentation keeps stored visible hours for off-day fixtures")
-    func presentationVisibleHoursFallbackForOffDayFixtures() {
+    @Test("PricesFeature presentation hides stale off-day hours")
+    func presentationVisibleHoursHideStaleOffDayHours() {
         let payload = DailyPricingSnapshotPayload.dayValue
         var state = PricesFeature.State()
         state.hourlyPrices = payload.hourlyPrices
@@ -196,8 +196,8 @@ struct PricesFeatureTests {
         let presentationNow = state.presentationNow(timelineDate: offDayNow, calendar: calendar)
         let visiblePrices = state.presentationVisibleHourlyPrices(now: offDayNow, calendar: calendar)
 
-        #expect(presentationNow == payload.hourlyPrices.first?.date)
-        #expect(visiblePrices == state.visibleHourlyPrices)
+        #expect(presentationNow == offDayNow)
+        #expect(visiblePrices.isEmpty)
     }
 
 }

--- a/Tests/Features/PricesFeatureTests.swift
+++ b/Tests/Features/PricesFeatureTests.swift
@@ -169,6 +169,37 @@ struct PricesFeatureTests {
         }
     }
 
+    @Test("PricesFeature presentation hides past hours when current hour advances")
+    func presentationVisibleHoursFollowTimelineDate() {
+        let payload = DailyPricingSnapshotPayload.dayValue
+        var state = PricesFeature.State()
+        state.hourlyPrices = payload.hourlyPrices
+        state.visibleHourlyPrices = Array(payload.hourlyPrices[10...23])
+        let calendar = Calendar(identifier: .gregorian)
+        let now = payload.dayStart.addingTimeInterval((11 * 3_600) + 1_200)
+
+        let visiblePrices = state.presentationVisibleHourlyPrices(now: now, calendar: calendar)
+
+        #expect(visiblePrices == Array(payload.hourlyPrices[11...23]))
+        #expect(state.presentationCurrentHourDate(now: now, calendar: calendar) == payload.hourlyPrices[11].date)
+    }
+
+    @Test("PricesFeature presentation keeps stored visible hours for off-day fixtures")
+    func presentationVisibleHoursFallbackForOffDayFixtures() {
+        let payload = DailyPricingSnapshotPayload.dayValue
+        var state = PricesFeature.State()
+        state.hourlyPrices = payload.hourlyPrices
+        state.visibleHourlyPrices = Array(payload.hourlyPrices[10...23])
+        let calendar = Calendar(identifier: .gregorian)
+        let offDayNow = payload.dayStart.addingTimeInterval(48 * 3_600)
+
+        let presentationNow = state.presentationNow(timelineDate: offDayNow, calendar: calendar)
+        let visiblePrices = state.presentationVisibleHourlyPrices(now: offDayNow, calendar: calendar)
+
+        #expect(presentationNow == payload.hourlyPrices.first?.date)
+        #expect(visiblePrices == state.visibleHourlyPrices)
+    }
+
 }
 
 private extension DailyPricingSnapshotPayload {

--- a/Tests/Snapshots/Issue11SnapshotTests.swift
+++ b/Tests/Snapshots/Issue11SnapshotTests.swift
@@ -40,7 +40,8 @@ struct Issue11SnapshotTests {
         }
         let view = PricesView(
             onHourTapped: { _ in },
-            state: .snapshotContent
+            state: .snapshotContent,
+            timelineDateOverride: .issue11SnapshotTimelineDate
         )
 
         assertIssue11Snapshot(of: applySnapshotEnvironment(to: view))
@@ -53,7 +54,8 @@ struct Issue11SnapshotTests {
         }
         let view = PricesView(
             onHourTapped: { _ in },
-            state: .snapshotWidgetContent
+            state: .snapshotWidgetContent,
+            timelineDateOverride: .issue11SnapshotTimelineDate
         )
 
         assertIssue11Snapshot(
@@ -74,7 +76,8 @@ struct Issue11SnapshotTests {
         }
         let view = PricesView(
             onHourTapped: { _ in },
-            state: .snapshotWidgetEmpty
+            state: .snapshotWidgetEmpty,
+            timelineDateOverride: .issue11SnapshotTimelineDate
         )
 
         assertIssue11Snapshot(
@@ -212,6 +215,10 @@ struct Issue11SnapshotTests {
             assertion()
         }
     }
+}
+
+private extension Date {
+    static let issue11SnapshotTimelineDate = Date(timeIntervalSince1970: 1_700_003_600)
 }
 
 private extension PricesFeature.State {


### PR DESCRIPTION
## Summary
- Refresh the in-app prices widget with a live timeline date.
- Derive visible hourly rows from the current local hour so past prices stay hidden.
- Add regression coverage for timeline-driven presentation filtering.

## Validation
- xcodebuild test -scheme PrecioLuzApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max'
- scripts/check_tca_warnings.sh --log /tmp/precioluzapp-build.log
- scripts/check_secrets.sh
- swiftlint lint --strict Sources/Features/PricesFeature/PricesView.swift Sources/Features/PricesFeature/PricesFeature.swift Sources/Features/PricesFeature/PricesHourlyListSectionView.swift Tests/Features/PricesFeatureTests.swift

Note: full swiftlint still reports pre-existing violations outside the touched files.